### PR TITLE
Fixed curl target for bash script - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Long story short, there is a small script that can help you setup and launch it 
 
 
 ```bash
-curl https://raw.githubusercontent.com/andypetrella/spark-notebook/master/run.sh | bash
+curl https://raw.githubusercontent.com/andypetrella/spark-notebook/spark/run.sh | bash
 ```
 
 ## Longer story


### PR DESCRIPTION
The URL on the readme is broken. Should be:
curl https://raw.githubusercontent.com/andypetrella/spark-notebook/spark/run.sh
