### PR TITLE
Fixed less.jsm to point to working source

### DIFF
--- a/server/src/main/assets/thirdparty/static/less.jsm
+++ b/server/src/main/assets/thirdparty/static/less.jsm
@@ -1,1 +1,1 @@
-https://raw.github.com/cloudhead/less.js/master/dist/less-1.3.3.js
+https://raw.githubusercontent.com/less/less.js/v1.7.5/dist/less-1.3.3.js


### PR DESCRIPTION
Server was not building because it could not find Cloudhead's version of less
