### PR TITLE
Provided Spark and assembly

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,6 @@ resolvers += Resolver.url(
   url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/")
 )(Resolver.ivyStylePatterns)
 
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+
 addSbtPlugin("com.untyped" %% "sbt-js" % "0.6")

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -33,6 +33,5 @@ notebook {
     
     ###
     # REPL compiler options
-    #compilerArgs=[]
-    
+    #compilerArgs=[]    
 }

--- a/server/src/main/scala/Server.scala
+++ b/server/src/main/scala/Server.scala
@@ -73,6 +73,7 @@ object Server extends Logging {
     val secure = !args.contains("--disable_security")
 
     logInfo("Running SN Server in " + config.notebooksDir.getAbsolutePath)
+
     val host = if (config.kernelVMConfig.hasPath("hostname")) config.kernelVMConfig.getString("hostname") else "127.0.0.1"
     val port = (if (config.kernelVMConfig.hasPath("port")) Try(config.kernelVMConfig.getInt("port")).toOption else None) getOrElse choosePort(host)
     val security = if (secure) new ClientAuth(host, port) else Insecure
@@ -117,8 +118,8 @@ object Server extends Logging {
 
     val obsInt = unfiltered.netty.websockets.Planify(withWSAuth(new ObservableIntent(app.system).webSocketIntent)).onPass(_.fireChannelRead(_))
 
-    val iPythonRes = Resources(getClass.getResource("/from_ipython/"), 3600, true)
-    val thirdPartyRes = Resources(getClass.getResource("/thirdparty/"), 3600, true)
+    //val iPythonRes = Resources(getClass.getResource("/from_ipython/"), 0, true)
+    //val thirdPartyRes = Resources(getClass.getResource("/thirdparty/"), 3600, true)
 
     //TODO: absolute URL's may not be portable, should they be supported?  If not, are resources defined relative to notebooks dir or module root?
     def userResourceURL(res: File) = {
@@ -146,7 +147,10 @@ object Server extends Logging {
       .handler(templatesPlan)
 
       /* Workaround for https://github.com/unfiltered/unfiltered/issues/139 */
-      .pipe(resourcePlan(iPythonRes, thirdPartyRes))
+      //.pipe(resourcePlan(iPythonRes))
+      //.pipe(resourcePlan(thirdPartyRes))
+      //.resources(getClass.getResource("/from_ipython/"), 3600, true)
+      .resources(getClass.getResource("/thirdparty/"), 3600, true)
       .pipe(resourcePlan(moduleRes: _*))
       .pipe(resourcePlan(observableRes))
       .run({


### PR DESCRIPTION
Spark is now a provided deps, which allows easiest integration with other spark flavors if needed (→  wrapping project)

Assembly is configured but behaves weirdly → some resources cannot be loaded from jars, hours of explorations are suspecting
that folder in jar containing lots of entries exploses the netty resource loader...
