### PR TITLE
Hadoop 2.3 & Hadoop 2.4 support

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,7 @@ object Dependencies {
   // FIXME
   val sparkEnabledModules = List("common", "kernel", "subprocess")
   val crossConf = Map(
-    "1.1.0" → List("1.0.4", "2.0.0-cdh4.2.0")
+    "1.1.0" → List("1.0.4", "2.0.0-cdh4.2.0", "2.3.0", "2.4.0")
   )
 
   def distAll = Command.command("distAll") { state =>


### PR DESCRIPTION
closes #62 

Hadoop 2.3 & 2.4 (among cdh4) are the officially supported Hadoop versions for Spark 1.1.0 on https://spark.apache.org/downloads.html