### PR TITLE
clean config and kernel uses some tuning params now... but globally :-/

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -169,9 +169,9 @@ object Application extends Controller {
   }
 
   def startKernel(kernelId: String)(implicit request:RequestHeader) = {
-    val compilerArgs = config.kernelCompilerArgs.toList
-    val initScripts = config.kernelInitScripts.toList
-    val kernel = new Kernel(kernelSystem)
+    val compilerArgs = config.kernel.compilerArgs.toList
+    val initScripts = config.kernel.initScripts.toList
+    val kernel = new Kernel(config.kernel.config.underlying, kernelSystem)
     KernelManager.add(kernelId, kernel)
 
     val service = new CalcWebSocketService(kernelSystem, initScripts, compilerArgs, kernel.remoteDeployFuture)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -58,37 +58,45 @@ logger.play=INFO
 logger.application=DEBUG
 
 manager {
-  notebook {
+  ###
+  # Server dir (containing notebook files)
+  #notebooks.dir=./conf/notebooks
+
+  ###
+  # Static resources to be made available on the web server
+  # You may add your own resource directories
+  # Paths may be relative to the server root, or absolute.
+  #resources=["./my-resources"]
+
+  ##
+  # Name of SparkNotebook
+  #name = spark-notebook
+
+  kernel {
     ###
-    # Uncomment to enable attachment of a remote debugger (you will likely either need to change the port on the line below, or configure your debugger to connect to the specified port)
+    # Uncomment to enable attachment of a remote debugger 
+    # (you will likely either need to change the port on the line below, or configure your debugger to connect to the specified port)
     #vmArgs=["-agentlib:jdwp=transport=dt_socket,address=localhost:9000,server=y,suspend=y"]
 
     ###
     # Working directory for kernel VMs
-    #kernel.dir=.
+    #dir=.
 
-    ###
-    # Server dir (containing notebook files)
-    #notebooks.dir=.
 
     ###
     # List of URLs of kernel init scripts (to be run when a kernel first starts).
-    #kernel.init=[]
+    #init=[]
 
     ###
     # Kernel VM memory settings
     #heap=4g
-    #permGen=128m
-
-    ###
-    # Static resources to be made available on the web server
-    # You may add your own resource directories
-    # Paths may be relative to the server root, or absolute.
-    #resources=["./my-resources"]
+    #stack=-1 #default XSS
+    #permGen=1204m
+    #reservedCodeCache=-1 #default
 
     ###
     # Classpath for kernel VMs (defaults to server VM classpath)
-    #kernel.classpath=[]
+    #classpath=[]
 
     ###
     # REPL compiler options

--- a/modules/subprocess/src/main/scala/notebook/Kernel.scala
+++ b/modules/subprocess/src/main/scala/notebook/Kernel.scala
@@ -1,12 +1,17 @@
 package notebook
 
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+import scala.concurrent._
+import scala.concurrent.duration._
+
 import akka.actor._
 import akka.actor.Deploy
-import scala.concurrent._
+
+import com.typesafe.config.Config
+
 import kernel.remote.{RemoteActorSystem, RemoteActorProcess}
-import scala.concurrent.duration._
-import java.util.concurrent.ConcurrentHashMap
-import scala.collection.JavaConverters._
 
 /**
  * A kernel is a remote VM with a set of sub-actors, each of which interacts with  local resources (for example, WebSockets).
@@ -15,7 +20,7 @@ import scala.collection.JavaConverters._
  * to the remote (this is accomplished by blocking on startup waiting for
  */
 
-class Kernel(system: ActorSystem) {
+class Kernel(config:Config, system: ActorSystem) {
   implicit val executor = system.dispatcher
 
   val router = system.actorOf(Props(new ExecutionManager))
@@ -33,7 +38,7 @@ class Kernel(system: ActorSystem) {
     var remoteInfo: RemoteActorSystem = null
 
     override def preStart() {
-      remoteInfo = Await.result( RemoteActorSystem.spawn(system, "kernel"), 1 minutes)
+      remoteInfo = Await.result(RemoteActorSystem.spawn(config, system, "kernel"), 1 minutes)
       remoteDeployPromise.success(remoteInfo.deploy)
     }
 

--- a/modules/subprocess/src/main/scala/notebook/kernel/pfork/BetterFork.scala
+++ b/modules/subprocess/src/main/scala/notebook/kernel/pfork/BetterFork.scala
@@ -26,6 +26,8 @@ import org.apache.log4j.PropertyConfigurator
 
 import org.slf4j.LoggerFactory
 
+import com.typesafe.config.{ConfigFactory, Config}
+
 import play.api.{Play, Logger}
 
 
@@ -43,20 +45,20 @@ trait ForkableProcess {
 /**
  * I am so sick of this being a thing that gets implemented everywhere. Let's abstract.
  */
-class BetterFork[A <: ForkableProcess : reflect.ClassTag](executionContext: ExecutionContext ) {
+class BetterFork[A <: ForkableProcess : reflect.ClassTag](config:Config, executionContext: ExecutionContext) {
   private implicit val ec = executionContext
 
   import BetterFork._
 
   val processClass = (implicitly[reflect.ClassTag[A]]).runtimeClass
 
-  def workingDirectory = new File(".")
-  def heap: Long = defaultHeap
-  def stack: Long = -1
-  def permGen: Long = -1
-  def reservedCodeCache: Long = -1
+  def workingDirectory = new File(if (config.hasPath("wd")) config.getString("wd") else ".")
+  def heap: Long = if (config.hasPath("heap")) config.getBytes("heap") else defaultHeap
+  def stack: Long = if (config.hasPath("stack")) config.getBytes("stack") else -1
+  def permGen: Long = if (config.hasPath("permGen")) config.getBytes("permGen") else -1
+  def reservedCodeCache: Long = if (config.hasPath("reservedCodeCache")) config.getBytes("reservedCodeCache") else -1
   def server: Boolean = true
-  def debug: Boolean = false // If true, then you will likely get address in use errors spawning multiple processes
+  def debug: Boolean = if (config.hasPath("debug")) config.getBoolean("debug") else false // If true, then you will likely get address in use errors spawning multiple processes
   def classPath: IndexedSeq[String] = defaultClassPath
   def classPathString = classPath.mkString(File.pathSeparator)
 

--- a/modules/subprocess/src/main/scala/notebook/kernel/remote/RemoteActorSystem.scala
+++ b/modules/subprocess/src/main/scala/notebook/kernel/remote/RemoteActorSystem.scala
@@ -6,15 +6,20 @@
  */
 package notebook.kernel.remote
 
-import notebook.kernel.pfork.{ProcessInfo, BetterFork, ForkableProcess}
-import akka.actor._
-import com.typesafe.config.ConfigFactory
-import akka.remote.{RemoteScope, RemoteActorRefProvider}
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.typesafe.config.{ConfigFactory, Config}
+
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import java.io.File
+
+import akka.actor._
+import akka.remote.{RemoteScope, RemoteActorRefProvider}
+
 import org.apache.commons.io.FileUtils
-import java.util.concurrent.atomic.AtomicInteger
+
+import notebook.kernel.pfork.{ProcessInfo, BetterFork, ForkableProcess}
 
 /**
  * Author: Ken
@@ -93,7 +98,7 @@ class RemoteActorSystem(localSystem: ActorSystem, info: ProcessInfo, remoteConte
  */
 object RemoteActorSystem {
   val nextId = new AtomicInteger(1)
-  def spawn(system: ActorSystem, configFile:String): Future[RemoteActorSystem] = {
+  def spawn(config:Config, system: ActorSystem, configFile:String): Future[RemoteActorSystem] = {
     //val cookiePath = AkkaConfigUtils.requiredCookie(system.settings.config) match {
     //  case Some(cookie) =>
     //    val cookieFile = new File(".", ".akka-cookie")
@@ -102,6 +107,6 @@ object RemoteActorSystem {
     //  case _ => ""
     //}cookiePath
      val cookiePath = ""
-    new BetterFork[RemoteActorProcess](system.dispatcher).execute(configFile, cookiePath) map { new RemoteActorSystem(system, _) }
+    new BetterFork[RemoteActorProcess](config, system.dispatcher).execute(configFile, cookiePath) map { new RemoteActorSystem(system, _) }
   }
 }


### PR DESCRIPTION
Sometimes, PermGen exceptions could occur in the forked process (spark -- if a lot of jars are needed in the spark context for instance). Thus this PR adds to ability to configure this jvm option.

The downside is that these options are for all or none forked processes.