### PR TITLE
Added Java 7 as a requirement in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ Long story short, there are several ways to start the spark notebook quickly (ev
  * Docker image
  * DEB package
 
-However, there are several flavors for these distribtions that depends on the Spark version and Hadoop version you are using.
+However, there are several flavors for these distributions that depends on the Spark version and Hadoop version you are using.
+
+#### Requirements
+* Make sure you're running at least Java 7 (`sudo apt-get install openjdk-7-jdk`).
 
 #### ZIP
 The zip distributions are publicly available in the bucket: <a href="http://s3.eu-central-1.amazonaws.com/spark-notebook/index.html">s3://spark-notebook</a>.


### PR DESCRIPTION
I was trying to get this running inside of Vagrant with the default hashicorp/precise32 image (Ubuntu 12). `sudo apt-get install default-jdk` installs OpenJDK 6, which generates an error when you try to open the notebook in your browser.

I'm not sure the user really needs the JDK or if the JRE would suffice.