### PR TITLE
Moved :dp to the top to avoid underlying clean removing variables

### DIFF
--- a/conf/notebooks/ADAM.snb
+++ b/conf/notebooks/ADAM.snb
@@ -24,6 +24,14 @@
       "collapsed" : true
     },
     "cell_type" : "code",
+    "source" : ":dp org.bdgenomics.adam % adam-apis % 0.15.0\n- org.apache.hadoop % hadoop-client %   _\n- org.apache.spark  %     _         %   _\n- org.scala-lang    %     _         %   _\n- org.scoverage     %     _         %   _",
+    "outputs" : [ ]
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : true
+    },
+    "cell_type" : "code",
     "source" : "import sys.process._\nval master = (\"ec2-metadata --public-hostname\"!!).drop(\"public-hostname: \".size).mkString.trim",
     "outputs" : [ ]
   }, {
@@ -33,14 +41,6 @@
     },
     "cell_type" : "code",
     "source" : "def hu(s:String) = s\"hdfs://$master:9010/temp/$s\"",
-    "outputs" : [ ]
-  }, {
-    "metadata" : {
-      "trusted" : true,
-      "collapsed" : true
-    },
-    "cell_type" : "code",
-    "source" : ":dp org.bdgenomics.adam % adam-apis % 0.15.0\n- org.apache.hadoop % hadoop-client %   _\n- org.apache.spark  %     _         %   _\n- org.scala-lang    %     _         %   _\n- org.scoverage     %     _         %   _",
     "outputs" : [ ]
   }, {
     "metadata" : {

--- a/conf/notebooks/Convert ADAM.snb
+++ b/conf/notebooks/Convert ADAM.snb
@@ -21,6 +21,18 @@
   }, {
     "metadata" : { },
     "cell_type" : "markdown",
+    "source" : "Setting Spark with ADAM libs"
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : true
+    },
+    "cell_type" : "code",
+    "source" : ":dp org.bdgenomics.adam % adam-apis % 0.15.0\n- org.apache.hadoop % hadoop-client %   _\n- org.apache.spark  %     _         %   _\n- org.scala-lang    %     _         %   _\n- org.scoverage     %     _         %   _",
+    "outputs" : [ ]
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
     "source" : "Check the master name to construct the HDFS and configure Spark"
   }, {
     "metadata" : {
@@ -41,18 +53,6 @@
     },
     "cell_type" : "code",
     "source" : "def hu(s:String) = s\"hdfs://$master:9010/temp/$s\"\nval vcfFile = hu(\"ALL.chr1.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.vcf\")\nval outputFile = vcfFile+\".adam\"  ",
-    "outputs" : [ ]
-  }, {
-    "metadata" : { },
-    "cell_type" : "markdown",
-    "source" : "Setting Spark with ADAM libs"
-  }, {
-    "metadata" : {
-      "trusted" : true,
-      "collapsed" : true
-    },
-    "cell_type" : "code",
-    "source" : ":dp org.bdgenomics.adam % adam-apis % 0.15.0\n- org.apache.hadoop % hadoop-client %   _\n- org.apache.spark  %     _         %   _\n- org.scala-lang    %     _         %   _\n- org.scoverage     %     _         %   _",
     "outputs" : [ ]
   }, {
     "metadata" : { },

--- a/conf/notebooks/Read 1000Genomes dataset (chr-N).snb
+++ b/conf/notebooks/Read 1000Genomes dataset (chr-N).snb
@@ -49,6 +49,30 @@
   }, {
     "metadata" : { },
     "cell_type" : "markdown",
+    "source" : "## Setting up the running env."
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
+    "source" : "Setting Spark with ADAM libs (this has to be done first because it resets variables)"
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : false
+    },
+    "cell_type" : "code",
+    "source" : ":local-repo /tmp/spark-notebook/repo",
+    "outputs" : [ ]
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : false
+    },
+    "cell_type" : "code",
+    "source" : ":dp org.bdgenomics.adam % adam-apis % 0.15.0\n- org.apache.hadoop % hadoop-client %   _\n- org.apache.spark  %     _         %   _\n- org.scala-lang    %     _         %   _\n- org.scoverage     %     _         %   _",
+    "outputs" : [ ]
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
     "source" : "## The process"
   }, {
     "metadata" : { },
@@ -84,31 +108,7 @@
       "collapsed" : false
     },
     "cell_type" : "code",
-    "source" : "val adamFileOnS3 = \"s3://med-at-scale/1000genomes/ALL.chr1.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.vcf.adam\"",
-    "outputs" : [ ]
-  }, {
-    "metadata" : { },
-    "cell_type" : "markdown",
-    "source" : "## Setting up the running env."
-  }, {
-    "metadata" : { },
-    "cell_type" : "markdown",
-    "source" : "Setting Spark with ADAM libs"
-  }, {
-    "metadata" : {
-      "trusted" : true,
-      "collapsed" : false
-    },
-    "cell_type" : "code",
-    "source" : ":local-repo /tmp/spark-notebook/repo",
-    "outputs" : [ ]
-  }, {
-    "metadata" : {
-      "trusted" : true,
-      "collapsed" : false
-    },
-    "cell_type" : "code",
-    "source" : ":dp org.bdgenomics.adam % adam-apis % 0.15.0\n- org.apache.hadoop % hadoop-client %   _\n- org.apache.spark  %     _         %   _\n- org.scala-lang    %     _         %   _\n- org.scoverage     %     _         %   _",
+    "source" : "val adamFileOnS3 = \"s3n://med-at-scale/1000genomes/ALL.chr1.integrated_phase1_v3.20101123.snps_indels_svs.genotypes.vcf.adam\"",
     "outputs" : [ ]
   }, {
     "metadata" : { },


### PR DESCRIPTION
When loading dependencies, variables previously assigned get reset. (ADAM notebooks)