### PR TITLE
fixes #109

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -249,7 +249,7 @@ object Application extends Controller {
     }
   }
 
-  def saveNotebook(snb:String) = Action(parse.tolerantJson) { request =>
+  def saveNotebook(snb:String) = Action(parse.tolerantJson(maxLength = 1024 * 1014 /*1Mb*/)) { request =>
     val notebook = NBSerializer.fromJson(request.body \ "content")
     try {
       nbm.save(snb.dropRight(".snb".size), snb, notebook, true)


### PR DESCRIPTION
just raised the content allowed to be sent over PUT (save) up to one mega byte.

Which is already quite a lot for a json output, but hey there can be a lot of HMTL (plot and so on)