### PR TITLE
fixes #28

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -3,18 +3,22 @@ package controllers
 import java.util.UUID
 
 import scala.util.Try
-import scala.concurrent.Promise
+import scala.concurrent.{Promise, Future}
+import scala.concurrent.duration._
 
 import play.api._
 import play.api.mvc._
 import play.api.mvc.BodyParsers.parse._
-import play.api.libs.json._
+import play.api.libs.functional.syntax._
 import play.api.libs.iteratee._
 import play.api.libs.iteratee.Concurrent.Channel
+import play.api.libs.json._
 
 import com.typesafe.config._
 
 import akka.actor._
+import akka.pattern.ask
+import akka.util.Timeout
 
 import notebook._
 import notebook.server._
@@ -92,16 +96,28 @@ object Application extends Controller {
     )
   }
 
-  private [this] def newSession(kernelId:Option[String]=None) = {
+  private [this] def newSession(kernelId:Option[String]=None, notebookPath:Option[String]=None) = {
     val kId = kernelId.getOrElse(UUID.randomUUID.toString)
     val compilerArgs = config.kernel.compilerArgs.toList
     val initScripts = config.kernel.initScripts.toList
     val kernel = new Kernel(config.kernel.config.underlying, kernelSystem)
     KernelManager.add(kId, kernel)
 
-    val service = new CalcWebSocketService(kernelSystem, initScripts, compilerArgs, kernel.remoteDeployFuture)
+    val r = Reads.map[String]
+
+    // Load the notebook → get the metadata → get custom → git it to CalcWebSocketService
+    val custom:Option[Map[String, String]] = for {
+      p <- notebookPath
+      n <- nbm.load(p.dropRight(".snb".size))
+      m <- n.metadata
+      c <- m.custom
+      _ = Logger.info("CUSTOM::: " + c)
+      map <- r.reads(c).asOpt
+    } yield map
+    val service = new CalcWebSocketService(kernelSystem, custom, initScripts, compilerArgs, kernel.remoteDeployFuture)
     kernelIdToCalcService += kId -> service
 
+    // todo add MD?
     Json.parse(
       s"""
       |{
@@ -120,35 +136,38 @@ object Application extends Controller {
   def createSession() = Action(parse.tolerantJson)/* → posted as urlencoded form oO */ { request =>
     val json:JsValue = request.body
     val kernelId = Try((json \ "kernel" \ "id").as[String]).toOption
-    val k = newSession(kernelId)
+    val notebookPath = Try((json \ "notebook" \ "path").as[String]).toOption
+    val k = newSession(kernelId, notebookPath)
     Ok(Json.obj("kernel" → k))
   }
 
   def sessions() = Action {
-    Ok(Json.obj()) // TODO
+    Ok(Json.obj()) // TODO using kernelIdToCalcService
   }
 
-  def clusters() = Action {
-    Ok(Json.arr(
-      Json.parse(
-        s"""
-        |{
-        |  "profile": "Standalone",
-        |  "name": "spark://...",
-        |  "status": "stopped"
-        |}
-        |""".stripMargin.trim
-      ),
-      Json.parse(
-        s"""
-        |{
-        |  "profile": "Mesos",
-        |  "name": "mesos://zk://...",
-        |  "status": "stopped"
-        |}
-        |""".stripMargin.trim
-      )
-    ))
+
+  val clustersActor = kernelSystem.actorOf(Props( new NotebookClusters ))
+  implicit val GetClustersTimeout = Timeout(60 seconds)
+
+  def clusters() = Action.async {
+    implicit val ec = kernelSystem.dispatcher
+    (clustersActor ? NotebookClusters.All).map { case all:List[JsObject] =>
+      Ok(JsArray(all))
+    }
+  }
+
+  def addCluster() = Action.async(parse.tolerantJson) { request =>
+    val json = request.body
+    implicit val ec = kernelSystem.dispatcher
+    json match {
+      case o:JsObject =>
+        (clustersActor ? NotebookClusters.Add((json \ "name").as[String], o)).map { case cluster:JsObject =>
+          Ok(cluster)
+        }
+      case _ => Future {
+        BadRequest("Add cluster needs an object, got: " + json)
+      }
+    }
   }
 
   def contents(`type`:String) = Action {
@@ -178,8 +197,15 @@ object Application extends Controller {
     getNotebook(name, name+".snb", "json")
   }
 
-  def newNotebook() = Action {
-    val name = nbm.newNotebook()
+  def newNotebook() = Action(parse.tolerantText) { request =>
+    val text = request.body
+    val customMetadata = Try(text).flatMap(j => Try(Json.parse(j) \ "custom")).toOption flatMap {
+      case x:JsObject  => Some(x)
+      case `JsNull`    => None
+      case y           => throw new RuntimeException("Cannot created notebook with " + y)
+    }
+
+    val name = nbm.newNotebook(customMetadata)
     Logger.info("new: " + name)
     Redirect(routes.Application.content("notebook", name))
   }
@@ -229,7 +255,9 @@ object Application extends Controller {
     //shouldn't do anything since onClose should be called in openKernel (stopChannels is call in the front)
     // /!\ this won't kill the underneath actor!!!
     closeKernel(kernelId)
-    Ok(newSession())
+
+    // TODO → the notebookPath here!!!
+    Ok(newSession(notebookPath=None))
   }
 
   def listCheckpoints(snb:String) = Action { request =>

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -129,7 +129,26 @@ object Application extends Controller {
   }
 
   def clusters() = Action {
-    Ok(Json.obj())
+    Ok(Json.arr(
+      Json.parse(
+        s"""
+        |{
+        |  "profile": "Standalone",
+        |  "name": "spark://...",
+        |  "status": "stopped"
+        |}
+        |""".stripMargin.trim
+      ),
+      Json.parse(
+        s"""
+        |{
+        |  "profile": "Mesos",
+        |  "name": "mesos://zk://...",
+        |  "status": "stopped"
+        |}
+        |""".stripMargin.trim
+      )
+    ))
   }
 
   def contents(`type`:String) = Action {

--- a/app/notebook/CalcWebSocketService.scala
+++ b/app/notebook/CalcWebSocketService.scala
@@ -14,11 +14,11 @@ import notebook.client._
 /**
  * Provides a web-socket interface to the Calculator
  */
-class CalcWebSocketService(system: ActorSystem, initScripts: List[(String, String)], compilerArgs: List[String], remoteDeployFuture: Future[Deploy]) {
+class CalcWebSocketService(system: ActorSystem, customSparkConf:Option[Map[String, String]], initScripts: List[(String, String)], compilerArgs: List[String], remoteDeployFuture: Future[Deploy]) {
   implicit val executor = system.dispatcher
 
   val wsPromise = Promise[WebSockWrapper]
-  val calcActor = system.actorOf(Props( new CalcActor))
+  val calcActor = system.actorOf(Props( new CalcActor ))
 
   class CalcActor extends Actor with ActorLogging {
     private var currentSessionOperation: Option[ActorRef] = None
@@ -30,8 +30,9 @@ class CalcWebSocketService(system: ActorSystem, initScripts: List[(String, Strin
       // that we don't want, then akka's attempts at serialization will fail and kittens everywhere will cry.
       val kCompilerArgs = compilerArgs
       val kInitScripts = initScripts
+      val kCustomSparkConf = customSparkConf
       val remoteDeploy = Await.result(remoteDeployFuture, 2 minutes)
-      calculator = context.actorOf(Props(new ReplCalculator(kInitScripts, kCompilerArgs)).withDeploy(remoteDeploy))
+      calculator = context.actorOf(Props(new ReplCalculator(kInitScripts, kCustomSparkConf, kCompilerArgs)).withDeploy(remoteDeploy))
     }
 
     override def preStart() {
@@ -127,4 +128,3 @@ class CalcWebSocketService(system: ActorSystem, initScripts: List[(String, Strin
     }
   }
 }
-

--- a/app/notebook/NBSerializer.scala
+++ b/app/notebook/NBSerializer.scala
@@ -60,7 +60,9 @@ object NBSerializer {
   implicit val languageInfoFormat:Format[LanguageInfo] = Json.format[LanguageInfo]
   val scala:LanguageInfo = LanguageInfo("scala", "scala", "text/x-scala")
 
-  case class Metadata(name: String, user_save_timestamp: Date = new Date(0), auto_save_timestamp: Date = new Date(0), language_info:LanguageInfo=scala, trusted:Boolean=true)
+  case class Metadata(name: String, user_save_timestamp: Date = new Date(0),
+                      auto_save_timestamp: Date = new Date(0), language_info:LanguageInfo=scala,
+                      trusted:Boolean=true, custom:Option[JsObject]=None)
   implicit val metadataFormat:Format[Metadata] = {
     val f = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     val r:Reads[Metadata] = (
@@ -68,7 +70,8 @@ object NBSerializer {
       (JsPath \ "user_save_timestamp").read[String].map(x => f.parse(x)) and
       (JsPath \ "auto_save_timestamp").read[String].map(x => f.parse(x)) and
       (JsPath \ "language_info").readNullable[LanguageInfo].map(_.getOrElse(scala)) and
-      (JsPath \ "trusted").readNullable[Boolean].map(_.getOrElse(true))
+      (JsPath \ "trusted").readNullable[Boolean].map(_.getOrElse(true)) and
+      (JsPath \ "custom").readNullable[JsObject]
     )(Metadata.apply _)
 
     val w:Writes[Metadata] =
@@ -83,7 +86,8 @@ object NBSerializer {
           "user_save_timestamp" → user_save_timestamp,
           "auto_save_timestamp" → auto_save_timestamp,
           "language_info" → language_info,
-          "trusted" → trusted
+          "trusted" → trusted,
+          "custom" → m.custom
         )
       }
 

--- a/app/notebook/NotebookClusters.scala
+++ b/app/notebook/NotebookClusters.scala
@@ -1,0 +1,73 @@
+package notebook
+package server
+
+import scala.concurrent._
+import scala.concurrent.duration._
+
+import akka.actor._
+
+import play.api.libs.json._
+
+class NotebookClusters(initClusters: Map[String, JsObject] = NotebookClusters.examples) extends Actor with ActorLogging {
+  import NotebookClusters._
+
+  var clusters:Map[String, JsObject] = initClusters
+
+  def receive = {
+    case Add(name, o)    =>
+      clusters = clusters + (name → o)
+      sender ! o
+    case Remove(name, o) => clusters = clusters - name
+    case Get(name)       => sender ! clusters.get(name)
+    case All             => sender ! clusters.values.toList
+  }
+}
+
+object NotebookClusters {
+  case class Add(name:String, o:JsObject)
+  case class Remove(name:String, o:JsObject)
+  case class Get(name:String)
+  case object All
+
+  val standalone = """
+  |{
+  |  "spark.app.name": "Notebook",
+  |  "spark.master": "spark://<master>:<port>",
+  |  "spark.executor.memory": "512m"
+  |}
+  """.stripMargin
+
+  val mesos = """
+  |{
+  |  "spark.app.name": "Notebook",
+  |  "spark.master": "mesos://<master>:<port>",
+  |  "spark.executor.memory": "512m",
+  |  "spark.executor.uri": "hdfs://<spark>.tgz",
+  |  "spark.driver.host": "<host>",
+  |  "spark.local.dir": "<path>"
+  |}
+  """.stripMargin
+
+  val examples:Map[String, JsObject] = Map(
+    ("Standalone" → Json.parse(
+      s"""
+      |{
+      |  "profile": "Standalone",
+      |  "name": "ec2 <host>",
+      |  "status": "stopped",
+      |  "template" : $standalone
+      |}
+      |""".stripMargin.trim
+    ).asInstanceOf[JsObject]),
+    ("Mesos" → Json.parse(
+      s"""
+      |{
+      |  "profile": "Mesos",
+      |  "name": "Integration env",
+      |  "status": "stopped",
+      |  "template" : $mesos
+      |}
+      |""".stripMargin.trim
+    ).asInstanceOf[JsObject])
+  )
+}

--- a/app/notebook/NotebookManager.scala
+++ b/app/notebook/NotebookManager.scala
@@ -45,9 +45,9 @@ class NotebookManager(val name: String, val notebookDir: File) {
     Stream.from(1) map { i => base + i } filterNot { fn => notebookFile(fn).exists() } head
   }
 
-  def newNotebook() = {
+  def newNotebook(customMetadata:Option[JsObject]=None) = {
     val name = incrementFileName("Untitled")
-    val nb = Notebook(Some(new Metadata(name)), Some(Nil), None, None, None)
+    val nb = Notebook(Some(new Metadata(name, custom=customMetadata)), Some(Nil), None, None, None)
     val path = name+extension
     save(name, path, nb, false)
     name
@@ -61,7 +61,7 @@ class NotebookManager(val name: String, val notebookDir: File) {
       val path = name
     	save(name, path, Notebook(Some(new Metadata(name)), oldNB.cells, oldNB.worksheets, oldNB.autosaved, None), false)
     	path
-    } getOrElse newNotebook
+    } getOrElse newNotebook()
   }
 
   /**

--- a/app/views/projectdashboard.scala.html
+++ b/app/views/projectdashboard.scala.html
@@ -4,6 +4,7 @@
   <!-- stylesheet -->
   <script src="" type="text/javascript" charset="utf-8"></script>
   <link rel="stylesheet" href="@routes.Assets.at("ipython/style/style.min.css")" type="text/css"/>
+  <link rel="stylesheet" href="@routes.Assets.at("ipython/components/codemirror/lib/codemirror.css")">
  }{
   <!-- meta -->
 
@@ -135,7 +136,7 @@
         <div id="clusters" class="tab-pane">
           <div id="cluster_toolbar" class="row">
             <div class="col-xs-8 no-padding">
-              <span id="cluster_list_info">IPython parallel computing clusters</span>
+              <span id="cluster_list_info">Spark clusters</span>
             </div>
             <div class="col-xs-4 no-padding tree-buttons">
               <span id="cluster_buttons" class="pull-right">
@@ -146,8 +147,8 @@
           <div id="cluster_list">
             <div id="cluster_list_header" class="row list_header">
               <div class="profile_col col-xs-4">profile</div>
+              <div class="name_col col-xs-3" title="The name of the cluster">Name</div>
               <div class="status_col col-xs-3">status</div>
-              <div class="engines_col col-xs-3" title="Enter the number of engines to start or empty for default"># of engines</div>
               <div class="action_col col-xs-2">action</div>
             </div>
           </div>

--- a/app/views/projectdashboard.scala.html
+++ b/app/views/projectdashboard.scala.html
@@ -140,6 +140,7 @@
             </div>
             <div class="col-xs-4 no-padding tree-buttons">
               <span id="cluster_buttons" class="pull-right">
+              <button id="refresh_add_cluster" title="Add cluster profile" class="btn btn-default btn-xs"><i class="fa fa-plus"></i></button>
               <button id="refresh_cluster_list" title="Refresh cluster list" class="btn btn-default btn-xs"><i class="fa fa-refresh"></i></button>
               </span>
             </div>

--- a/conf/routes
+++ b/conf/routes
@@ -33,6 +33,7 @@ GET     /files/*path                                                  controller
 GET     /nbconvert/:format/*path                                      controllers.Application.dlNotebookAs(path:String, format:String)
 
 GET     /clusters                                                     controllers.Application.clusters()
+POST    /clusters                                                     controllers.Application.addCluster()
 
 
 # Web Sockets

--- a/conf/scripts/init.sc
+++ b/conf/scripts/init.sc
@@ -16,7 +16,7 @@ import org.apache.spark.repl.SparkILoop
 
 @transient val uri = _5C4L4_N0T3800K_5P4RK_HOOK
 
-@transient var conf = new SparkConf()
+@transient var conf = new SparkConf().setAll(_5C4L4_N0T3800K_5P4RK_C0NF.toList)
 
 @transient var sparkContext:SparkContext = _
 
@@ -25,6 +25,7 @@ def reset(appName:String="Notebook", lastChanges:(SparkConf=>Unit)=(_:SparkConf)
   conf.setMaster(sparkMaster.getOrElse("local[*]"))
       .setAppName(appName)
       .set("spark.repl.class.uri", uri)
+      .setAll(_5C4L4_N0T3800K_5P4RK_C0NF.toList)
 
   execMemory foreach (v => conf.set("spark.executor.memory", v))
   execUri foreach (v => conf.set("spark.executor.uri", v))

--- a/public/ipython/base/js/dialog.js
+++ b/public/ipython/base/js/dialog.js
@@ -7,7 +7,7 @@ define(function(require) {
     var CodeMirror = require('codemirror/lib/codemirror');
     var IPython = require('base/js/namespace');
     var $ = require('jquery');
-    
+
     /**
      * A wrapper around bootstrap modal for easier use
      * Pass it an option dictionary with the following properties:
@@ -24,13 +24,13 @@ define(function(require) {
      *    - notebook : notebook instance
      *    - keyboard_manager: keyboard manager instance.
      *
-     *  Unlike bootstrap modals, the backdrop options is set by default 
+     *  Unlike bootstrap modals, the backdrop options is set by default
      *  to 'static'.
      *
-     *  The rest of the options are passed as is to bootstrap modals. 
+     *  The rest of the options are passed as is to bootstrap modals.
      *
      *  btn_options: dict with the following property:
-     *  
+     *
      *    - click : callback to trigger on click
      *    - class : css classes to add to button.
      *
@@ -71,9 +71,9 @@ define(function(require) {
                 options.body || $("<p/>")
             )
         );
-        
+
         var footer = $("<div/>").addClass("modal-footer");
-        
+
         for (var label in options.buttons) {
             var btn_opts = options.buttons[label];
             var button = $("<button/>")
@@ -98,7 +98,7 @@ define(function(require) {
                 }
             }, 0);
         });
-        
+
         // destroy modal on hide, unless explicitly asked not to
         if (options.destroy === undefined || options.destroy) {
             modal.on("hidden.bs.modal", function () {
@@ -115,13 +115,13 @@ define(function(require) {
                 options.keyboard_manager.command_mode();
             }
         });
-        
+
         if (options.keyboard_manager) {
             options.keyboard_manager.disable();
         }
 
         options.backdrop = options.backdrop || 'static';
-        
+
         return modal.modal(options);
     };
 
@@ -139,7 +139,7 @@ define(function(require) {
     var edit_metadata = function (options) {
         options.name = options.name || "Cell";
         var error_div = $('<div/>').css('color', 'red');
-        var message = 
+        var message =
             "Manually edit the JSON below to manipulate the metadata for this " + options.name + "." +
             " We recommend putting custom metadata attributes in an appropriately named sub-structure," +
             " so they don't conflict with those of others.";
@@ -149,7 +149,7 @@ define(function(require) {
             .attr('cols', '80')
             .attr('name', 'metadata')
             .text(JSON.stringify(options.md || {}, null, 2));
-        
+
         var dialogform = $('<div/>').attr('title', 'Edit the metadata')
             .append(
                 $('<form/>').append(
@@ -198,11 +198,76 @@ define(function(require) {
 
         modal_obj.on('shown.bs.modal', function(){ editor.refresh(); });
     };
-    
+
+    // TODO: merge with edit_metadata  → almost identical
+    var conf_cluster = function (options) {
+        options.name = options.name || "Cell";
+        var error_div = $('<div/>').css('color', 'red');
+        var message =
+            "Manually edit the JSON below to manipulate the configuration for this "+ options.profile + "cluster " + options.name + ".";
+
+        var textarea = $('<textarea/>')
+            .attr('rows', '13')
+            .attr('cols', '80')
+            .attr('name', 'conf')
+            .text(JSON.stringify(options.template || {}, null, 2));
+
+        var dialogform = $('<div/>').attr('title', 'Configuration for the cluster ' + options.name)
+            .append(
+                $('<form/>').append(
+                    $('<fieldset/>').append(
+                        $('<label/>')
+                        .attr('for','conf')
+                        .text(message)
+                        )
+                        .append(error_div)
+                        .append($('<br/>'))
+                        .append(textarea)
+                    )
+            );
+        var editor = CodeMirror.fromTextArea(textarea[0], {
+            lineNumbers: true,
+            matchBrackets: true,
+            indentUnit: 2,
+            autoIndent: true,
+            mode: 'application/json',
+        });
+
+        // preformat for
+        var modal_obj = modal({
+            title: "Edit " + options.name + " Configuration",
+            body: dialogform,
+            buttons: {
+                OK: { class : "btn-primary",
+                    click: function() {
+                        /**
+                         * validate json and set it
+                         */
+                        var new_conf;
+                        try {
+                            new_conf = JSON.parse(editor.getValue());
+                        } catch(e) {
+                            console.log(e);
+                            error_div.text('WARNING: Could not save invalid JSON.');
+                            return false;
+                        }
+                        // TODO → create and configure SparkContext wrt configuration
+                        alert("create and configure SparkContext wrt configuration");;
+                        options.callback(new_conf);
+                    }
+                },
+                Cancel: {}
+            }
+        });
+
+        modal_obj.on('shown.bs.modal', function(){ editor.refresh(); });
+    };
+
     var dialog = {
         modal : modal,
         kernel_modal : kernel_modal,
         edit_metadata : edit_metadata,
+        conf_cluster : conf_cluster
     };
 
     // Backwards compatability.

--- a/public/ipython/base/js/dialog.js
+++ b/public/ipython/base/js/dialog.js
@@ -201,7 +201,7 @@ define(function(require) {
 
     // TODO: merge with edit_metadata  → almost identical
     var conf_cluster = function (options) {
-        options.name = options.name || "Cell";
+        options.name = options.name || "Cluster";
         var error_div = $('<div/>').css('color', 'red');
         var message =
             "Manually edit the JSON below to manipulate the configuration for this "+ options.profile + "cluster " + options.name + ".";
@@ -251,8 +251,6 @@ define(function(require) {
                             error_div.text('WARNING: Could not save invalid JSON.');
                             return false;
                         }
-                        // TODO → create and configure SparkContext wrt configuration
-                        alert("create and configure SparkContext wrt configuration");;
                         options.callback(new_conf);
                     }
                 },
@@ -263,6 +261,67 @@ define(function(require) {
         modal_obj.on('shown.bs.modal', function(){ editor.refresh(); });
     };
 
+
+    // TODO: merge with edit_metadata  → almost identical
+    var new_cluster = function (options) {
+        options.name = options.name || "Cluster";
+        var error_div = $('<div/>').css('color', 'red');
+        var message = "Create a cluster template as JSON.";
+
+        var textarea = $('<textarea/>')
+            .attr('rows', '13')
+            .attr('cols', '80')
+            .attr('name', 'conf')
+            .text(JSON.stringify(options.template || { profile: options.profile }, null, 2));
+
+        var dialogform = $('<div/>').attr('title', 'Configuration for the cluster ' + options.name)
+            .append(
+                $('<form/>').append(
+                    $('<fieldset/>').append(
+                        $('<label/>')
+                        .attr('for','conf')
+                        .text(message)
+                        )
+                        .append(error_div)
+                        .append($('<br/>'))
+                        .append(textarea)
+                    )
+            );
+        var editor = CodeMirror.fromTextArea(textarea[0], {
+            lineNumbers: true,
+            matchBrackets: true,
+            indentUnit: 2,
+            autoIndent: true,
+            mode: 'application/json',
+        });
+
+        // preformat for
+        var modal_obj = modal({
+            title: "Edit " + options.name + " Configuration",
+            body: dialogform,
+            buttons: {
+                OK: { class : "btn-primary",
+                    click: function() {
+                        /**
+                         * validate json and set it
+                         */
+                        var new_md;
+                        try {
+                            new_md = JSON.parse(editor.getValue());
+                        } catch(e) {
+                            console.log(e);
+                            error_div.text('WARNING: Could not save invalid JSON.');
+                            return false;
+                        }
+                        options.callback(new_md);
+                    }
+                },
+                Cancel: {}
+            }
+        });
+
+        modal_obj.on('shown.bs.modal', function(){ editor.refresh(); });
+    };
     var dialog = {
         modal : modal,
         kernel_modal : kernel_modal,

--- a/public/ipython/services/contents.js
+++ b/public/ipython/services/contents.js
@@ -2,248 +2,251 @@
 // Distributed under the terms of the Modified BSD License.
 
 define(function(require) {
-    "use strict";
+  "use strict";
 
-    var $ = require('jquery');
-    var utils = require('base/js/utils');
+  var $ = require('jquery');
+  var utils = require('base/js/utils');
 
-    var Contents = function(options) {
-        /**
-         * Constructor
-         *
-         * A contents handles passing file operations
-         * to the back-end.  This includes checkpointing
-         * with the normal file operations.
-         *
-         * Parameters:
-         *  options: dictionary
-         *      Dictionary of keyword arguments.
-         *          base_url: string
-         */
-        this.base_url = options.base_url;
-    };
-
-    /** Error type */
-    Contents.DIRECTORY_NOT_EMPTY_ERROR = 'DirectoryNotEmptyError';
-
-    Contents.DirectoryNotEmptyError = function() {
-        // Constructor
-        //
-        // An error representing the result of attempting to delete a non-empty
-        // directory.
-        this.message = 'A directory must be empty before being deleted.';
-    };
-    
-    Contents.DirectoryNotEmptyError.prototype = Object.create(Error.prototype);
-    Contents.DirectoryNotEmptyError.prototype.name =
-        Contents.DIRECTORY_NOT_EMPTY_ERROR;
-
-
-    Contents.prototype.api_url = function() {
-        var url_parts = [this.base_url, 'api/contents'].concat(
-                                Array.prototype.slice.apply(arguments));
-        return utils.url_join_encode.apply(null, url_parts);
-    };
-
+  var Contents = function(options) {
     /**
-     * Creates a basic error handler that wraps a jqXHR error as an Error.
+     * Constructor
      *
-     * Takes a callback that accepts an Error, and returns a callback that can
-     * be passed directly to $.ajax, which will wrap the error from jQuery
-     * as an Error, and pass that to the original callback.
+     * A contents handles passing file operations
+     * to the back-end.  This includes checkpointing
+     * with the normal file operations.
      *
-     * @method create_basic_error_handler
-     * @param{Function} callback
-     * @return{Function}
+     * Parameters:
+     *  options: dictionary
+     *    Dictionary of keyword arguments.
+     *      base_url: string
      */
-    Contents.prototype.create_basic_error_handler = function(callback) {
-        if (!callback) {
-            return utils.log_ajax_error;
+    this.base_url = options.base_url;
+  };
+
+  /** Error type */
+  Contents.DIRECTORY_NOT_EMPTY_ERROR = 'DirectoryNotEmptyError';
+
+  Contents.DirectoryNotEmptyError = function() {
+    // Constructor
+    //
+    // An error representing the result of attempting to delete a non-empty
+    // directory.
+    this.message = 'A directory must be empty before being deleted.';
+  };
+
+  Contents.DirectoryNotEmptyError.prototype = Object.create(Error.prototype);
+  Contents.DirectoryNotEmptyError.prototype.name =
+    Contents.DIRECTORY_NOT_EMPTY_ERROR;
+
+
+  Contents.prototype.api_url = function() {
+    var url_parts = [this.base_url, 'api/contents'].concat(
+                Array.prototype.slice.apply(arguments));
+    return utils.url_join_encode.apply(null, url_parts);
+  };
+
+  /**
+   * Creates a basic error handler that wraps a jqXHR error as an Error.
+   *
+   * Takes a callback that accepts an Error, and returns a callback that can
+   * be passed directly to $.ajax, which will wrap the error from jQuery
+   * as an Error, and pass that to the original callback.
+   *
+   * @method create_basic_error_handler
+   * @param{Function} callback
+   * @return{Function}
+   */
+  Contents.prototype.create_basic_error_handler = function(callback) {
+    if (!callback) {
+      return utils.log_ajax_error;
+    }
+    return function(xhr, status, error) {
+      callback(utils.wrap_ajax_error(xhr, status, error));
+    };
+  };
+
+  /**
+   * File Functions (including notebook operations)
+   */
+
+  /**
+   * Get a file.
+   *
+   * @method get
+   * @param {String} path
+   * @param {Object} options
+   *  type : 'notebook', 'file', or 'directory'
+   *  format: 'text' or 'base64'; only relevant for type: 'file'
+   *  content: true or false; // whether to include the content
+   */
+  Contents.prototype.get = function (path, options) {
+    /**
+     * We do the call with settings so we can set cache to false.
+     */
+    var settings = {
+      processData : false,
+      cache : false,
+      type : "GET",
+      dataType : "json",
+    };
+    var url = this.api_url(path);
+    var params = {};
+    if (options.type) { params.type = options.type; }
+    if (options.format) { params.format = options.format; }
+    if (options.content === false) { params.content = '0'; }
+    return utils.promising_ajax(url + '?' + $.param(params), settings);
+  };
+
+
+  /**
+   * Creates a new untitled file or directory in the specified directory path.
+   *
+   * @method new
+   * @param {String} path: the directory in which to create the new file/directory
+   * @param {Object} options:
+   *    ext: file extension to use
+   *    type: model type to create ('notebook', 'file', or 'directory')
+   */
+  Contents.prototype.new_untitled = function(path, options) {
+    options.custom = options.custom.originalEvent?null:options.custom
+    var data = JSON.stringify({
+      ext: options.ext,
+      type: options.type,
+      custom: options.custom
+    });
+
+    var settings = {
+      processData : false,
+      type : "POST",
+      data : data,
+      contentType: "application/json; charset=utf-8",
+      dataType : "json",
+    };
+    return utils.promising_ajax(this.api_url(path), settings);
+  };
+
+  Contents.prototype.delete = function(path) {
+    var settings = {
+      processData : false,
+      type : "DELETE",
+      dataType : "json",
+    };
+    var url = this.api_url(path);
+    return utils.promising_ajax(url, settings).catch(
+      // Translate certain errors to more specific ones.
+      function(error) {
+        // TODO: update IPEP27 to specify errors more precisely, so
+        // that error types can be detected here with certainty.
+        if (error.xhr.status === 400) {
+          throw new Contents.DirectoryNotEmptyError();
         }
-        return function(xhr, status, error) {
-            callback(utils.wrap_ajax_error(xhr, status, error));
-        };
-    };
+        throw error;
+      }
+    );
+  };
 
+  Contents.prototype.rename = function(path, new_path) {
+    var data = {path: new_path};
+    var settings = {
+      processData : false,
+      type : "PATCH",
+      data : JSON.stringify(data),
+      dataType: "json",
+      contentType: 'application/json',
+    };
+    var url = this.api_url(path);
+    return utils.promising_ajax(url, settings);
+  };
+
+  Contents.prototype.save = function(path, model) {
     /**
-     * File Functions (including notebook operations)
+     * We do the call with settings so we can set cache to false.
      */
+    var settings = {
+      processData : false,
+      type : "PUT",
+      dataType: "json",
+      data : JSON.stringify(model),
+      contentType: 'application/json',
+    };
+    var url = this.api_url(path);
+    return utils.promising_ajax(url, settings);
+  };
 
+  Contents.prototype.copy = function(from_file, to_dir) {
     /**
-     * Get a file.
-     *
-     * @method get
-     * @param {String} path
-     * @param {Object} options
-     *    type : 'notebook', 'file', or 'directory'
-     *    format: 'text' or 'base64'; only relevant for type: 'file'
-     *    content: true or false; // whether to include the content
+     * Copy a file into a given directory via POST
+     * The server will select the name of the copied file
      */
-    Contents.prototype.get = function (path, options) {
-        /**
-         * We do the call with settings so we can set cache to false.
-         */
-        var settings = {
-            processData : false,
-            cache : false,
-            type : "GET",
-            dataType : "json",
-        };
-        var url = this.api_url(path);
-        var params = {};
-        if (options.type) { params.type = options.type; }
-        if (options.format) { params.format = options.format; }
-        if (options.content === false) { params.content = '0'; }
-        return utils.promising_ajax(url + '?' + $.param(params), settings);
+    var url = this.api_url(to_dir);
+
+    var settings = {
+      processData : false,
+      type: "POST",
+      data: JSON.stringify({copy_from: from_file}),
+      dataType : "json",
     };
+    return utils.promising_ajax(url, settings);
+  };
 
+  /**
+   * Checkpointing Functions
+   */
 
-    /**
-     * Creates a new untitled file or directory in the specified directory path.
-     *
-     * @method new
-     * @param {String} path: the directory in which to create the new file/directory
-     * @param {Object} options:
-     *      ext: file extension to use
-     *      type: model type to create ('notebook', 'file', or 'directory')
-     */
-    Contents.prototype.new_untitled = function(path, options) {
-        var data = JSON.stringify({
-          ext: options.ext,
-          type: options.type
-        });
-
-        var settings = {
-            processData : false,
-            type : "POST",
-            data: data,
-            dataType : "json",
-        };
-        return utils.promising_ajax(this.api_url(path), settings);
+  Contents.prototype.create_checkpoint = function(path) {
+    var url = this.api_url(path, 'checkpoints');
+    var settings = {
+      type : "POST",
+      dataType : "json",
     };
+    return utils.promising_ajax(url, settings);
+  };
 
-    Contents.prototype.delete = function(path) {
-        var settings = {
-            processData : false,
-            type : "DELETE",
-            dataType : "json",
-        };
-        var url = this.api_url(path);
-        return utils.promising_ajax(url, settings).catch(
-            // Translate certain errors to more specific ones.
-            function(error) {
-                // TODO: update IPEP27 to specify errors more precisely, so
-                // that error types can be detected here with certainty.
-                if (error.xhr.status === 400) {
-                    throw new Contents.DirectoryNotEmptyError();
-                }
-                throw error;
-            }
-        );
+  Contents.prototype.list_checkpoints = function(path) {
+    var url = this.api_url(path, 'checkpoints');
+    var settings = {
+      type : "GET",
+      cache: false,
+      dataType: "json",
     };
+    return utils.promising_ajax(url, settings);
+  };
 
-    Contents.prototype.rename = function(path, new_path) {
-        var data = {path: new_path};
-        var settings = {
-            processData : false,
-            type : "PATCH",
-            data : JSON.stringify(data),
-            dataType: "json",
-            contentType: 'application/json',
-        };
-        var url = this.api_url(path);
-        return utils.promising_ajax(url, settings);
+  Contents.prototype.restore_checkpoint = function(path, checkpoint_id) {
+    var url = this.api_url(path, 'checkpoints', checkpoint_id);
+    var settings = {
+      type : "POST",
     };
+    return utils.promising_ajax(url, settings);
+  };
 
-    Contents.prototype.save = function(path, model) {
-        /**
-         * We do the call with settings so we can set cache to false.
-         */
-        var settings = {
-            processData : false,
-            type : "PUT",
-            dataType: "json",
-            data : JSON.stringify(model),
-            contentType: 'application/json',
-        };
-        var url = this.api_url(path);
-        return utils.promising_ajax(url, settings);
+  Contents.prototype.delete_checkpoint = function(path, checkpoint_id) {
+    var url = this.api_url(path, 'checkpoints', checkpoint_id);
+    var settings = {
+      type : "DELETE",
     };
-    
-    Contents.prototype.copy = function(from_file, to_dir) {
-        /**
-         * Copy a file into a given directory via POST
-         * The server will select the name of the copied file
-         */
-        var url = this.api_url(to_dir);
-        
-        var settings = {
-            processData : false,
-            type: "POST",
-            data: JSON.stringify({copy_from: from_file}),
-            dataType : "json",
-        };
-        return utils.promising_ajax(url, settings);
-    };
+    return utils.promising_ajax(url, settings);
+  };
 
-    /**
-     * Checkpointing Functions
-     */
+  /**
+   * File management functions
+   */
 
-    Contents.prototype.create_checkpoint = function(path) {
-        var url = this.api_url(path, 'checkpoints');
-        var settings = {
-            type : "POST",
-            dataType : "json",
-        };
-        return utils.promising_ajax(url, settings);
-    };
+  /**
+   * List notebooks and directories at a given path
+   *
+   * On success, load_callback is called with an array of dictionaries
+   * representing individual files or directories.  Each dictionary has
+   * the keys:
+   *   type: "notebook" or "directory"
+   *   created: created date
+   *   last_modified: last modified dat
+   * @method list_notebooks
+   * @param {String} path The path to list notebooks in
+   */
+  Contents.prototype.list_contents = function(path) {
+    return this.get(path, {type: 'directory'});
+  };
 
-    Contents.prototype.list_checkpoints = function(path) {
-        var url = this.api_url(path, 'checkpoints');
-        var settings = {
-            type : "GET",
-            cache: false,
-            dataType: "json",
-        };
-        return utils.promising_ajax(url, settings);
-    };
-
-    Contents.prototype.restore_checkpoint = function(path, checkpoint_id) {
-        var url = this.api_url(path, 'checkpoints', checkpoint_id);
-        var settings = {
-            type : "POST",
-        };
-        return utils.promising_ajax(url, settings);
-    };
-
-    Contents.prototype.delete_checkpoint = function(path, checkpoint_id) {
-        var url = this.api_url(path, 'checkpoints', checkpoint_id);
-        var settings = {
-            type : "DELETE",
-        };
-        return utils.promising_ajax(url, settings);
-    };
-
-    /**
-     * File management functions
-     */
-
-    /**
-     * List notebooks and directories at a given path
-     *
-     * On success, load_callback is called with an array of dictionaries
-     * representing individual files or directories.  Each dictionary has
-     * the keys:
-     *     type: "notebook" or "directory"
-     *     created: created date
-     *     last_modified: last modified dat
-     * @method list_notebooks
-     * @param {String} path The path to list notebooks in
-     */
-    Contents.prototype.list_contents = function(path) {
-        return this.get(path, {type: 'directory'});
-    };
-
-    return {'Contents': Contents};
+  return {'Contents': Contents};
 });

--- a/public/ipython/tree/js/clusterlist.js
+++ b/public/ipython/tree/js/clusterlist.js
@@ -2,192 +2,148 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
-    'jquery',
-    'base/js/utils',
-], function(IPython, $, utils) {
-    "use strict";
+  'base/js/namespace',
+  'jquery',
+  'base/js/utils',
+  'base/js/dialog',
+], function(IPython, $, utils, dialog) {
+  "use strict";
 
-    var ClusterList = function (selector, options) {
-        this.selector = selector;
-        if (this.selector !== undefined) {
-            this.element = $(selector);
-            this.style();
-            this.bind_events();
-        }
-        options = options || {};
-        this.options = options;
-        this.base_url = options.base_url || utils.get_body_data("baseUrl");
-        this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
+  var ClusterList = function (selector, options) {
+    this.selector = selector;
+    if (this.selector !== undefined) {
+      this.element = $(selector);
+      this.style();
+      this.bind_events();
+    }
+    options = options || {};
+    this.options = options;
+    this.base_url = options.base_url || utils.get_body_data("baseUrl");
+    this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
+  };
+
+  ClusterList.prototype.style = function () {
+    $('#cluster_list').addClass('list_container');
+    $('#cluster_toolbar').addClass('list_toolbar');
+    $('#cluster_list_info').addClass('toolbar_info');
+    $('#cluster_buttons').addClass('toolbar_buttons');
+  };
+
+
+  ClusterList.prototype.bind_events = function () {
+    var that = this;
+    $('#refresh_cluster_list').click(function () {
+      that.load_list();
+    });
+  };
+
+
+  ClusterList.prototype.load_list = function () {
+    var settings = {
+      processData : false,
+      cache : false,
+      type : "GET",
+      dataType : "json",
+      success : $.proxy(this.load_list_success, this),
+      error : utils.log_ajax_error,
     };
-
-    ClusterList.prototype.style = function () {
-        $('#cluster_list').addClass('list_container');
-        $('#cluster_toolbar').addClass('list_toolbar');
-        $('#cluster_list_info').addClass('toolbar_info');
-        $('#cluster_buttons').addClass('toolbar_buttons');
-    };
+    var url = utils.url_join_encode(this.base_url, 'clusters');
+    $.ajax(url, settings);
+  };
 
 
-    ClusterList.prototype.bind_events = function () {
-        var that = this;
-        $('#refresh_cluster_list').click(function () {
-            that.load_list();
-        });
-    };
+  ClusterList.prototype.clear_list = function () {
+    this.element.children('.list_item').remove();
+  };
+
+  ClusterList.prototype.load_list_success = function (data, status, xhr) {
+    this.clear_list();
+    var len = data.length;
+    for (var i=0; i<len; i++) {
+      var element = $('<div/>');
+      var item = new ClusterItem(element, this.options);
+      item.update_state(data[i]);
+      element.data('item', item);
+      this.element.append(element);
+    }
+  };
 
 
-    ClusterList.prototype.load_list = function () {
-        var settings = {
-            processData : false,
-            cache : false,
-            type : "GET",
-            dataType : "json",
-            success : $.proxy(this.load_list_success, this),
-            error : utils.log_ajax_error,
-        };
-        var url = utils.url_join_encode(this.base_url, 'clusters');
-        $.ajax(url, settings);
-    };
+  var ClusterItem = function (element, options) {
+    this.element = $(element);
+    this.base_url = options.base_url || utils.get_body_data("baseUrl");
+    this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
+    this.data = null;
+    this.style();
+  };
+
+  ClusterItem.prototype.style = function () {
+    this.element.addClass('list_item').addClass("row");
+  };
+
+  ClusterItem.prototype.update_state = function (data) {
+    this.data = data;
+    this.create();
+  };
 
 
-    ClusterList.prototype.clear_list = function () {
-        this.element.children('.list_item').remove();
-    };
-
-    ClusterList.prototype.load_list_success = function (data, status, xhr) {
-        this.clear_list();
-        var len = data.length;
-        for (var i=0; i<len; i++) {
-            var element = $('<div/>');
-            var item = new ClusterItem(element, this.options);
-            item.update_state(data[i]);
-            element.data('item', item);
-            this.element.append(element);
-        }
-    };
-
-
-    var ClusterItem = function (element, options) {
-        this.element = $(element);
-        this.base_url = options.base_url || utils.get_body_data("baseUrl");
-        this.notebook_path = options.notebook_path || utils.get_body_data("notebookPath");
-        this.data = null;
-        this.style();
-    };
-
-    ClusterItem.prototype.style = function () {
-        this.element.addClass('list_item').addClass("row");
-    };
-
-    ClusterItem.prototype.update_state = function (data) {
-        this.data = data;
-        if (data.status === 'running') {
-            this.state_running();
-        } else if (data.status === 'stopped') {
-            this.state_stopped();
-        }
-    };
-
-
-    ClusterItem.prototype.state_stopped = function () {
-        var that = this;
-        var profile_col = $('<div/>').addClass('profile_col col-xs-4').text(this.data.profile);
-        var status_col = $('<div/>').addClass('status_col col-xs-3').text('stopped');
-        var engines_col = $('<div/>').addClass('engine_col col-xs-3');
-        var input = $('<input/>').attr('type','number')
-                .attr('min',1)
-                .attr('size',3)
-                .addClass('engine_num_input form-control');
-        engines_col.append(input);
-        var start_button = $('<button/>').addClass("btn btn-default btn-xs").text("Start");
-        var action_col = $('<div/>').addClass('action_col col-xs-2').append(
-            $("<span/>").addClass("item_buttons btn-group").append(
-                start_button
-            )
-        );
-        this.element.empty()
-            .append(profile_col)
-            .append(status_col)
-            .append(engines_col)
-            .append(action_col);
-        start_button.click(function (e) {
-            var n = that.element.find('.engine_num_input').val();
-            if (!/^\d+$/.test(n) && n.length>0) {
-                status_col.text('invalid engine #');
-            } else {
-                var settings = {
-                    cache : false,
-                    data : {n:n},
-                    type : "POST",
-                    dataType : "json",
-                    success : function (data, status, xhr) {
-                        that.update_state(data);
-                    },
-                    error : function (xhr, status, error) {
-                        status_col.text("error starting cluster");
-                        utils.log_ajax_error(xhr, status, error);
-                    }
-                };
-                status_col.text('starting');
-                var url = utils.url_join_encode(
-                    that.base_url,
-                    'clusters',
-                    that.data.profile,
-                    'start'
-                );
-                $.ajax(url, settings);
-            }
-        });
-    };
-
-
-    ClusterItem.prototype.state_running = function () {
-        var that = this;
-        var profile_col = $('<div/>').addClass('profile_col col-xs-4').text(this.data.profile);
-        var status_col = $('<div/>').addClass('status_col col-xs-3').text('running');
-        var engines_col = $('<div/>').addClass('engines_col col-xs-3').text(this.data.n);
-        var stop_button = $('<button/>').addClass("btn btn-default btn-xs").text("Stop");
-        var action_col = $('<div/>').addClass('action_col col-xs-2').append(
-            $("<span/>").addClass("item_buttons btn-group").append(
-                stop_button
-            )
-        );
-        this.element.empty()
-            .append(profile_col)
-            .append(status_col)
-            .append(engines_col)
-            .append(action_col);
-        stop_button.click(function (e) {
-            var settings = {
-                cache : false,
-                type : "POST",
-                dataType : "json",
-                success : function (data, status, xhr) {
-                    that.update_state(data);
-                },
-                error : function (xhr, status, error) {
-                    utils.log_ajax_error(xhr, status, error),
-                    status_col.text("error stopping cluster");
-                }
+  ClusterItem.prototype.create = function () {
+    var that = this;
+    var profile_col = $('<div/>').addClass('profile_col col-xs-4').text(this.data.profile);
+    var status_col = $('<div/>').addClass('status_col col-xs-3').text('stopped');
+    var name_col = $('<div/>').addClass('name_col col-xs-3').text(this.data.name);
+    var create_button = $('<button/>').addClass("btn btn-default btn-xs").text("Create");
+    var action_col = $('<div/>').addClass('action_col col-xs-2').append(
+      $("<span/>").addClass("item_buttons btn-group").append(
+        create_button
+      )
+    );
+    this.element.empty()
+      .append(profile_col)
+      .append(name_col)
+      .append(status_col)
+      .append(action_col);
+    create_button.click(function (e) {
+      dialog.conf_cluster({
+          profile: that.profile,
+          template: that.template,
+          callback: function (conf) {
+              alert("TODO: create the notebook with the configuration: " + JSON.stringify(conf))
+              var settings = {
+              cache : false,
+              data : clusterConf,
+              type : "POST",
+              dataType : "json",
+              success : function (data, status, xhr) {
+                that.update_state(data);
+              },
+              error : function (xhr, status, error) {
+                status_col.text("error starting cluster");
+                utils.log_ajax_error(xhr, status, error);
+              }
             };
-            status_col.text('stopping');
+            status_col.text('starting');
             var url = utils.url_join_encode(
-                that.base_url,
-                'clusters',
-                that.data.profile,
-                'stop'
+              that.base_url,
+              'clusters',
+              that.data.profile,
+              'start'
             );
             $.ajax(url, settings);
+          },
+          name: that.name,
+          keyboard_manager: that.keyboard_manager
         });
-    };
+    });
+  };
 
-    // For backwards compatability.
-    IPython.ClusterList = ClusterList;
-    IPython.ClusterItem = ClusterItem;
 
-    return {
-        'ClusterList': ClusterList,
-        'ClusterItem': ClusterItem,
-    };
+  // For backwards compatability.
+  IPython.ClusterList = ClusterList;
+  IPython.ClusterItem = ClusterItem;
+
+  return {
+    'ClusterList': ClusterList,
+    'ClusterItem': ClusterItem,
+  };
 });

--- a/public/ipython/tree/js/main.js
+++ b/public/ipython/tree/js/main.js
@@ -40,7 +40,7 @@ require([
     "use strict";
 
     page = new page.Page();
-    
+
     var common_options = {
         base_url: utils.get_body_data("baseUrl"),
         notebook_path: utils.get_body_data("notebookPath"),
@@ -50,22 +50,21 @@ require([
     common_options.config = cfg;
     var common_config = new config.ConfigSection('common', common_options);
     common_config.load();
-    
+
     var session_list = new sesssionlist.SesssionList($.extend({
-        events: events}, 
+        events: events},
         common_options));
     var contents = new contents_service.Contents($.extend({
         events: events},
         common_options));
     var notebook_list = new notebooklist.NotebookList('#notebook_list', $.extend({
         contents: contents,
-        session_list:  session_list}, 
+        session_list:  session_list},
         common_options));
-    var cluster_list = new clusterlist.ClusterList('#cluster_list', common_options);
     var kernel_list = new kernellist.KernelList('#running_list',  $.extend({
-        session_list:  session_list}, 
+        session_list:  session_list},
         common_options));
-    
+
     var terminal_list;
     if (utils.get_body_data("terminalsAvailable") === "True") {
         terminal_list = new terminallist.TerminalList('#terminal_list', common_options);
@@ -79,6 +78,10 @@ require([
             common_options
         )
     );
+    var cluster_list = new clusterlist.ClusterList('#cluster_list', $.extend({
+        contents: contents,
+        new_notebook: new_buttons},
+        common_options));
 
     var interval_id=0;
     // auto refresh every xx secondes, no need to be fast,
@@ -137,15 +140,15 @@ require([
     events.trigger('app_initialized.DashboardApp');
     utils.load_extensions_from_config(cfg);
     utils.load_extensions_from_config(common_config);
-    
+
     // bound the upload method to the on change of the file select list
     $("#alternate_upload").change(function (event){
         notebook_list.handleFilesUpload(event,'form');
     });
-    
+
     // set hash on tab click
     $("#tabs").find("a").click(function(e) {
-        // Prevent the document from jumping when the active tab is changed to a 
+        // Prevent the document from jumping when the active tab is changed to a
         // tab that has a lot of content.
         e.preventDefault();
 
@@ -158,7 +161,7 @@ require([
             window.location.hash = hash;
         }
     });
-    
+
     // load tab if url hash
     if (window.location.hash) {
         $("#tabs").find("a[href=" + window.location.hash + "]").click();

--- a/public/ipython/tree/js/newnotebook.js
+++ b/public/ipython/tree/js/newnotebook.js
@@ -8,13 +8,13 @@ define([
     'base/js/dialog',
 ], function ($, IPython, utils, dialog) {
     "use strict";
-    
+
     var NewNotebookWidget = function (selector, options) {
         this.selector = selector;
         this.base_url = options.base_url;
         this.notebook_path = options.notebook_path;
         this.contents = options.contents;
-        this.default_kernel = null;
+        this.default_kernel = "spark";
         this.kernelspecs = {};
         if (this.selector !== undefined) {
             this.element = $(selector);
@@ -22,20 +22,20 @@ define([
         }
         this.bind_events();
     };
-    
+
     NewNotebookWidget.prototype.bind_events = function () {
         var that = this;
         this.element.find('#new_notebook').click(function () {
             that.new_notebook();
         });
     };
-    
+
     NewNotebookWidget.prototype.request_kernelspecs = function () {
         /** request and then load kernel specs */
         var url = utils.url_join_encode(this.base_url, 'api/kernelspecs');
         utils.promising_ajax(url).then($.proxy(this._load_kernelspecs, this));
     };
-    
+
     NewNotebookWidget.prototype._load_kernelspecs = function (data) {
         /** load kernelspec list */
         var that = this;
@@ -70,13 +70,13 @@ define([
             menu.after(li);
         }
     };
-    
-    NewNotebookWidget.prototype.new_notebook = function (kernel_name) {
+
+    NewNotebookWidget.prototype.new_notebook = function (kernel_name, customMetadata) {
         /** create and open a new notebook */
         var that = this;
         kernel_name = kernel_name || this.default_kernel;
         var w = window.open();
-        this.contents.new_untitled(that.notebook_path, {type: "notebook"}).then(
+        this.contents.new_untitled(that.notebook_path, {type: "notebook", custom: customMetadata}).then(
             function (data) {
                 var url = utils.url_join_encode(
                     that.base_url, 'notebooks', data.path
@@ -96,6 +96,6 @@ define([
             }
         );
     };
-    
+
     return {'NewNotebookWidget': NewNotebookWidget};
 });

--- a/public/javascripts/notebook/observable.js
+++ b/public/javascripts/notebook/observable.js
@@ -243,7 +243,6 @@ return new function () {
       me.start();
   } else {
     events.on('app_initialized.NotebookApp', function(o) {
-      alert("ok")
       me.start(); //avoid pre-init of IPython → .kernel.id is null
     });
   }


### PR DESCRIPTION
Features:

- [x]  clusters page lists predefined clusters that can be associated to new notebooks -- that is, the SparkConf will be set up for us by default without having to do it using `reset`
- [x]  create new notebooks based on a cluster definition (`create` button)
- [x]  adding new cluster definition (still has to be documented) → via `+` icon in the clusters page
- [ ]  clusters could be deleted... but misses the icon + action