### PR TITLE
fixes #133

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,15 @@ scalacOptions ++= Seq("-Xmax-classfile-name", "100")
 
 commands ++= Seq( distZips, distDebs, distAll, dockerPublishLocalAll, dockerPublishAll )
 
+val ClasspathPattern = "declare -r app_classpath=\"(.*)\"\n".r
+
+bashScriptDefines :=  bashScriptDefines.value.map {
+                              case ClasspathPattern(classpath) => "declare -r app_classpath=\"${HADOOP_CONF_DIR}:" + classpath + "\"\n"
+                              case _@entry => entry
+                          }
+
+//scriptClasspath += "${HADOOP_CONF_DIR}"
+
 dependencyOverrides += "log4j" % "log4j" % "1.2.16"
 
 dependencyOverrides += guava


### PR DESCRIPTION
Added (in a hackish way) support for injecting the  in the spark-notebook classpath

This will do the trick:
```
HADOOP_CONF_DIR=/etc/hadoop/conf ./bin/spark-notebook
```


/cc @virtualirfan @minyk → It's very limited (to linux machines for the moment) but IMHO good enough to go for now. WDYT? I'll release the notebook v0.4.0 with this in ~2hours if no comments.
Otherwise, we'll have more time to tune that in v0.5.0 (or patch it in v0.4.1)