### PR TITLE
Hadoop conf dir

### DIFF
--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -75,10 +75,11 @@ class ReplCalculator(
   private val shRegex = "(?s)^:sh\\s*(.+)\\s*$".r
 
   var resolvers:List[Resolver] = {
+    val mavenReleases    = sbt.DefaultMavenRepository
     val typesafeReleases = Resolver.typesafeIvyRepo("releases")
-    val jCenterReleases = Resolver.jcenterRepo
+    val jCenterReleases  = Resolver.jcenterRepo
     val sonatypeReleases = Resolver.sonatypeRepo("releases")
-    typesafeReleases :: jCenterReleases :: sonatypeReleases ::  customRepos.getOrElse(List.empty[String]).map(CustomResolvers.fromString _).map(_._2)
+    mavenReleases :: typesafeReleases :: jCenterReleases :: sonatypeReleases ::  customRepos.getOrElse(List.empty[String]).map(CustomResolvers.fromString _).map(_._2)
   }
 
   var repo:File = customLocalRepo.map(x => new File(x)).getOrElse{

--- a/modules/subprocess/src/main/scala/notebook/kernel/pfork/BetterFork.scala
+++ b/modules/subprocess/src/main/scala/notebook/kernel/pfork/BetterFork.scala
@@ -102,7 +102,7 @@ class BetterFork[A <: ForkableProcess : reflect.ClassTag](config:Config, executi
       log.info("Spawning %s".format(cmd.toString))
 
       // use environment because classpaths can be longer here than as a command line arg
-      val environment = System.getenv + ("CLASSPATH" -> classPathString)
+      val environment = System.getenv + ("CLASSPATH" -> (sys.env.get("HADOOP_CONF_DIR").map(_ + ":").getOrElse("")+classPathString))
       val exec = new KillableExecutor
 
       val completion = Promise[Int]

--- a/modules/subprocess/src/main/scala/notebook/kernel/pfork/ProcessFork.scala
+++ b/modules/subprocess/src/main/scala/notebook/kernel/pfork/ProcessFork.scala
@@ -68,7 +68,7 @@ class ProcessFork[A: reflect.ClassTag] {
     log.info("Spawning %s".format(cmd.toString))
 
     // use environment because classpaths can be longer here than as a command line arg
-    val environment = System.getenv + ("CLASSPATH" -> classPathString)
+    val environment = System.getenv + ("CLASSPATH" -> (sys.env.get("HADOOP_CONF_DIR").map(_ + ":").getOrElse("")+classPathString))
 
     val exec = new KillableExecutor
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
       "org.apache.spark"          %%         "spark-yarn"           %         v              excludeAll(ExclusionRule("org.apache.hadoop"), ExclusionRule("org.apache.ivy", "ivy"))
     }
   def sparkRepl(v:String)     = "org.apache.spark"          %%         "spark-repl"           %         v           excludeAll(ExclusionRule("org.apache.hadoop"))
-  def sparkSQL (v:String)     = "org.apache.spark"          %%         "spark-sql"            %         v           excludeAll(ExclusionRule("org.apache.hadoop"))
+  def sparkSQL (v:String)     = "org.apache.spark"          %%         "spark-sql"            %         v           excludeAll(ExclusionRule("org.apache.hadoop"), ExclusionRule("com.twitter", "parquet-column"), ExclusionRule("com.twitter", "parquet-hadoop"))
   val defaultHadoopVersion    = sys.props.getOrElse("hadoop.version", "1.0.4")
   def hadoopClient(v:String)  = "org.apache.hadoop"         %         "hadoop-client"         %         v           excludeAll(ExclusionRule("org.apache.commons", "commons-exec"), ExclusionRule("commons-codec", "commons-codec"))
   val defaultJets3tVersion    = sys.props.getOrElse("jets3t.version", "0.7.1")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,17 +88,17 @@ object Dependencies {
 
   object HadoopVersion extends Enumeration {
     type HadoopVersion = Value
-    val `1.0.4`, `2.0.0-cdh4.2.0`, `2.2.0`, `2.3.0`, `2.4.0`, `2.5.0-cdh5.3.2` = Value
+    val `1.0.4`, `2.0.0-cdh4.2.0`, `2.2.0`, `2.3.0`, `2.4.0`, `2.5.0`, `2.6.0`, `2.5.0-cdh5.3.1`, `2.5.0-cdh5.3.2` = Value
   }
 
   val crossConf = Map(
-    SparkVersion.`1.2.0` → { import HadoopVersion._; List(`1.0.4`, `2.0.0-cdh4.2.0`, `2.2.0`, `2.3.0`, `2.4.0`, `2.5.0-cdh5.3.2`) },
-    SparkVersion.`1.2.1` → { import HadoopVersion._; List(`1.0.4`, `2.0.0-cdh4.2.0`, `2.2.0`, `2.3.0`, `2.4.0`, `2.5.0-cdh5.3.2`) },
-    SparkVersion.`1.3.0` → { import HadoopVersion._; List(`1.0.4`, `2.0.0-cdh4.2.0`, `2.2.0`, `2.3.0`, `2.4.0`, `2.5.0-cdh5.3.2`) }
+    SparkVersion.`1.2.0` → { import HadoopVersion._; List(`1.0.4`, `2.0.0-cdh4.2.0`, `2.2.0`, `2.3.0`, `2.4.0`, `2.5.0`, `2.6.0`, `2.5.0-cdh5.3.1`, `2.5.0-cdh5.3.2`) },
+    SparkVersion.`1.2.1` → { import HadoopVersion._; List(`1.0.4`, `2.0.0-cdh4.2.0`, `2.2.0`, `2.3.0`, `2.4.0`, `2.5.0`, `2.6.0`, `2.5.0-cdh5.3.1`, `2.5.0-cdh5.3.2`) },
+    SparkVersion.`1.3.0` → { import HadoopVersion._; List(`1.0.4`, `2.0.0-cdh4.2.0`, `2.2.0`, `2.3.0`, `2.4.0`, `2.5.0`, `2.6.0`, `2.5.0-cdh5.3.1`, `2.5.0-cdh5.3.2`) }
   )
 
   val extraConf:Map[(SparkVersion.Value, HadoopVersion.Value), List[sbt.Def.Setting[_]]] = Map(
-    (SparkVersion.`1.2.0`, List(HadoopVersion.`2.3.0`)) → {
+    (SparkVersion.`1.2.0`, List(HadoopVersion.`2.3.0`, HadoopVersion.`2.4.0`, HadoopVersion.`2.5.0`, HadoopVersion.`2.6.0`, HadoopVersion.`2.5.0-cdh5.3.1`, HadoopVersion.`2.5.0-cdh5.3.2`)) → {
       List(
         Shared.jets3tVersion := "0.9.0",
         Shared.jets3tVersion in "common" := "0.9.0",
@@ -107,7 +107,7 @@ object Dependencies {
         Shared.jets3tVersion in "spark" := "0.9.0"
       )
     },
-    (SparkVersion.`1.2.1`, List(HadoopVersion.`2.3.0`)) → {
+    (SparkVersion.`1.2.1`, List(HadoopVersion.`2.3.0`, HadoopVersion.`2.4.0`, HadoopVersion.`2.5.0`, HadoopVersion.`2.6.0`, HadoopVersion.`2.5.0-cdh5.3.1`, HadoopVersion.`2.5.0-cdh5.3.2`)) → {
       List(
         Shared.jets3tVersion := "0.9.0",
         Shared.jets3tVersion in "common" := "0.9.0",
@@ -116,7 +116,7 @@ object Dependencies {
         Shared.jets3tVersion in "spark" := "0.9.0"
       )
     },
-    (SparkVersion.`1.3.0`, List(HadoopVersion.`2.3.0`)) → {
+    (SparkVersion.`1.3.0`, List(HadoopVersion.`2.3.0`, HadoopVersion.`2.4.0`, HadoopVersion.`2.5.0`, HadoopVersion.`2.6.0`, HadoopVersion.`2.5.0-cdh5.3.1`, HadoopVersion.`2.5.0-cdh5.3.2`)) → {
       List(
         Shared.jets3tVersion := "0.9.0",
         Shared.jets3tVersion in "common" := "0.9.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-RC1")
 


### PR DESCRIPTION
* remove parquet from spark-sql deps (which is only needed for the api)
* HADOOP_CONF_DIR always used if set (so, even in `run` mode)
* jets3 0.9.0 is now used for all known hadoop versions greater than 2.3.0
* maven central is now part of the resolves in SBT/scala-2.10