### PR TITLE
added some more context like markdown, plain, html for interpolations

### DIFF
--- a/app/notebook/server/CalcWebSocketService.scala
+++ b/app/notebook/server/CalcWebSocketService.scala
@@ -144,10 +144,11 @@ class CalcWebSocketService(
           case StreamResponse(data, name) =>
             ws.send(header, session, "stream", "iopub", obj("text" → data, "name" → name))
 
-          case ExecuteResponse(html) =>
+          case ExecuteResponse(outputType, content, time) =>
             ws.send(header, session, "execute_result", "iopub", obj(
               "execution_count" → counter,
-              "data" → obj("text/html" → html)
+              "data" → obj(outputType → content),
+              "time" → time
             ))
             ws.send(header, session, "status", "iopub", obj("execution_state" → "idle"))
             ws.send(header, session, "execute_reply", "shell", obj("execution_count" → counter))

--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -3,6 +3,8 @@ package notebook.client
 import java.io.File
 
 import akka.actor.{Actor, ActorRef, Props}
+
+import notebook.OutputTypes._
 import notebook.kernel._
 import notebook.util.{CustomResolvers, Deps, Match}
 import sbt._
@@ -32,6 +34,17 @@ class ReplCalculator(
   private val resolverRegex = "(?s)^:remote-repo\\s*(.+)\\s*$".r
   private val authRegex = """(?s)^\s*\(([^\)]+)\)\s*$""".r
   private val credRegex = """"([^"]+)"\s*,\s*"([^"]+)"""".r //"
+
+  private def outputTypesRegex(ctx:String, outputType:String) = s"(?s)^:$ctx\\s*\n(.+)\\s*$$".r → outputType
+  private val htmlContext       = outputTypesRegex("html",       `text/html`)
+  private val plainContext      = outputTypesRegex("plain",      `text/plain`)
+  private val markdownContext   = outputTypesRegex("markdown",   `text/markdown`)
+  private val latexContext      = outputTypesRegex("latex",      `text/latex`)
+  private val svgContext        = outputTypesRegex("svg",        `image/svg+xml`)
+  private val pngContext        = outputTypesRegex("png",        `image/png`)
+  private val jpegContext       = outputTypesRegex("jpeg",       `image/jpeg`)
+  private val pdfContext        = outputTypesRegex("pdf",        `application/pdf`)
+  private val javascriptContext = outputTypesRegex("javascript", `application/javascript`)
 
   private val cpRegex = "(?s)^:cp\\s*(.+)\\s*$".r
   private val dpRegex = "(?s)^:dp\\s*(.+)\\s*$".r
@@ -177,24 +190,22 @@ class ReplCalculator(
     }
 
     def execute(sender:ActorRef, er:ExecuteRequest):Unit = {
-      val newCode = er.code match {
+      val (outputType, newCode) = er.code match {
         case resolverRegex(r) =>
           log.debug("Adding resolver: " + r)
           val (logR, resolver) = CustomResolvers.fromString(r)
           resolvers = resolver :: resolvers
-          s""" "Resolver added: $logR!" """
+          (`text/plain`, s""" "Resolver added: $logR!" """)
 
         case repoRegex(r) =>
           log.debug("Updating local repo: " + r)
           repo = new File(r.trim)
           repo.mkdirs
-          s""" "Repo changed to ${repo.getAbsolutePath}!" """
+          (`text/plain`, s""" "Repo changed to ${repo.getAbsolutePath}!" """)
 
         case dpRegex(cp) =>
           log.debug("Fetching deps using repos: " + resolvers.mkString(" -- "))
-          eval( """""", notify = false)()
           val tryDeps = Deps.script(cp, resolvers, repo)
-          eval( """""", notify = false)()
 
           tryDeps match {
             case TSuccess(deps) =>
@@ -206,6 +217,7 @@ class ReplCalculator(
               preStartLogic()
               replay()
 
+              (`text/plain`,
               s"""
                  |//updating deps
                  |jars = (${deps.mkString("List(\"", "\",\"", "\")")} ::: jars.toList).distinct.toArray
@@ -213,9 +225,10 @@ class ReplCalculator(
                  |reset()
                  |jars.toList
                  """.stripMargin
+              )
             case TFailure(ex) =>
               log.error(ex, "Cannot add dependencies")
-              s""" <p style="color:red">${ex.getMessage}</p> """
+              (`text/html`, s""" <p style="color:red">${ex.getMessage}</p> """)
           }
 
         case cpRegex(cp) =>
@@ -230,26 +243,71 @@ class ReplCalculator(
           _repl = Some(_r)
           preStartLogic()
           replay()
-          s""""Classpath CHANGED!" """
+          (`text/plain`, s""""Classpath CHANGED!" """)
 
         case shRegex(sh) =>
           val ps = "s\"\"\"" + sh.replaceAll("\\s*\\|\\s*", "\" #\\| \"").replaceAll("\\s*&&\\s*", "\" #&& \"") + "\"\"\""
-          s"""
+          (`text/plain`, s"""
              |import sys.process._
-             |<pre>{$ps !!}</pre>
+             |$ps !!
               """.stripMargin.trim
+          )
 
         case sqlRegex(n, sql) =>
           log.debug(s"Received sql code: [$n] $sql")
           val qs = "\"\"\""
-          //if (!sqlGen.parts.isEmpty) {
           val name = Option(n).map(nm => s"@transient val $nm = ").getOrElse("")
-          s"""
+          (`text/plain`,
+            s"""
             import notebook.front.widgets.Sql
             import notebook.front.widgets.Sql._
             ${name}new Sql(sqlContext, s$qs$sql$qs)
             """
-        case _ => er.code
+          )
+
+        case htmlContext._1(content)        =>
+          val ctx = htmlContext._2
+          val c = content.toString.replaceAll("\"", "&quot;")
+          (ctx, " scala.xml.XML.loadString(s\"\"\""+c+"\"\"\") ")
+
+        case plainContext._1(content)       =>
+          val ctx = plainContext._2
+          val c = content.toString.replaceAll("\"", "\\\\\\\"")
+          (ctx, " s\"\"\""+c+"\"\"\" ")
+
+        case markdownContext._1(content)    =>
+          val ctx = markdownContext._2
+          val c = content.toString.replaceAll("\"", "\\\\\\\"")
+          (ctx, " s\"\"\""+c+"\"\"\" ")
+
+        case latexContext._1(content)       =>
+          val ctx = latexContext._2
+          val c = content.toString.replaceAll("\"", "\\\\\\\"")
+          (ctx, " s\"\"\""+c+"\"\"\" ")
+
+        case svgContext._1(content)         =>
+          val ctx = svgContext._2
+          val c = content.toString.replaceAll("\"", "&quot;")
+          (ctx, " scala.xml.XML.loadString(s\"\"\""+c+"\"\"\") ")
+
+        case pngContext._1(content)         =>
+          val ctx = pngContext._2
+          (ctx, content.toString)
+
+        case jpegContext._1(content)        =>
+          val ctx = jpegContext._2
+          (ctx, content.toString)
+
+        case pdfContext._1(content)         =>
+          val ctx = pdfContext._2
+          (ctx, content.toString)
+
+        case javascriptContext._1(content)  =>
+          val ctx = javascriptContext._2
+          val c = content.toString//.replaceAll("\"", "\\\"")
+          (ctx, " s\"\"\""+c+"\"\"\" ")
+
+        case whatever => (`text/html`, whatever)
       }
       val start = System.currentTimeMillis
       val thisSelf = self
@@ -264,7 +322,7 @@ class ReplCalculator(
 
       result foreach {
         case (timeToEval, Success(result)) =>
-          thisSender ! ExecuteResponse(result.toString + s"\n <div class='pull-right text-info'><small>$timeToEval</small></div>")
+          thisSender ! ExecuteResponse(outputType, result.toString, timeToEval)
         case (timeToEval, Failure(stackTrace)) =>
           thisSender ! ErrorResponse(stackTrace, incomplete = false)
         case (timeToEval, notebook.kernel.Incomplete) =>

--- a/modules/kernel/src/main/scala/notebook/Messages.scala
+++ b/modules/kernel/src/main/scala/notebook/Messages.scala
@@ -16,7 +16,7 @@ sealed trait CalcResponse
 
 case class StreamResponse(data: String, name: String) extends CalcResponse
 
-case class ExecuteResponse(html: String) extends CalcResponse
+case class ExecuteResponse(outputType:String, content: String, time:String) extends CalcResponse
 
 case class ErrorResponse(message: String, incomplete: Boolean) extends CalcResponse
 

--- a/modules/kernel/src/main/scala/notebook/OutputTypes.scala
+++ b/modules/kernel/src/main/scala/notebook/OutputTypes.scala
@@ -1,0 +1,13 @@
+package notebook
+
+object OutputTypes {
+  val `text/html`              =  "text/html"
+  val `text/plain`             =  "text/plain"
+  val `text/markdown`          =  "text/markdown"
+  val `text/latex`             =  "text/latex"
+  val `image/svg+xml`          =  "image/svg+xml"
+  val `image/png`              =  "image/png"
+  val `image/jpeg`             =  "image/jpeg"
+  val `application/pdf`        =  "application/pdf"
+  val `application/javascript` =  "application/javascript"
+}

--- a/public/ipython/notebook/js/outputarea.js
+++ b/public/ipython/notebook/js/outputarea.js
@@ -295,6 +295,7 @@ define([
             json.data = content.data;
             json.metadata = content.metadata;
             json.execution_count = content.execution_count;
+            json.time = content.time;
         } else if (msg_type === "error") {
             json.ename = content.ename;
             json.evalue = content.evalue;
@@ -513,9 +514,12 @@ define([
         this._safe_append(toinsert);
         // If we just output latex, typeset it.
         if ((json.data['text/latex'] !== undefined) ||
-            (json.data['text/html'] !== undefined) ||
+            /*(json.data['text/html'] !== undefined) ||*/
             (json.data['text/markdown'] !== undefined)) {
             this.typeset();
+        }
+        if (json.time) {
+            inserted.append($("<div class='pull-right text-info'><small>"+json.time+"</small></div>"))
         }
     };
 
@@ -675,6 +679,7 @@ define([
         var text_and_math = mathjaxutils.remove_math(markdown);
         var text = text_and_math[0];
         var math = text_and_math[1];
+        text = text.replace(/&quot;/g, '"');
         marked(text, function (err, html) {
             html = mathjaxutils.replace_math(html, math);
             toinsert.append(html);
@@ -697,6 +702,7 @@ define([
         // output can be inserted into at the time of JS execution.
         element = toinsert;
         try {
+            js = js.replace(/&quot;/g, '"');
             eval(js);
         } catch(err) {
             console.log(err);


### PR DESCRIPTION
fixes #31 by introducing more contexts, including `:markdown`

So an example of usage would be:

```
val file = "/tmp/data"
```

```
:markdown
## The data is located at "$file"
```

Which will print:
## The data is located at "/tmp/data"