### PR TITLE
Add the -deprecation warning by default

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -114,8 +114,9 @@ manager {
     #classpath=[]
 
     ###
-    # REPL compiler options
-    #compilerArgs=[]
+    # REPL compiler options: Use the deprecation warning by default for more
+    # useful feedback about obsolute functions, etc.
+    compilerArgs=[-deprecation]
   }
 
   clusters {


### PR DESCRIPTION
I think `-deprecation` for the Scala REPL should be on by default, so that users get useful warnings when they use a deprecated API. For example, when running the *Reactive SQL* example, `sqlContext.applySchema` is deprecated. Without `-deprecation`, you see:

```
warning: there was one deprecation warning; re-run with -deprecation for details.
...
```

With -deprecation, it actually tells you what the deprecation is:

```
<console>:66: warning: method applySchema in class SQLContext is deprecated: use createDataFrame
     val peopleSchemaRDD = sqlContext.applySchema(rowRDD, schema)
...
```