### PR TITLE
added with.parquet prop and spark repo for 1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ name := "spark-notebook"
 
 scalaVersion := defaultScalaVersion
 
-version in ThisBuild <<= (scalaVersion, sparkVersion, hadoopVersion, withHive) { (sc, sv, hv, h) => s"0.6.0-scala-$sc-spark-$sv-hadoop-$hv" + (if (h) "-with-hive" else "") }
+version in ThisBuild <<= (scalaVersion, sparkVersion, hadoopVersion, withHive, withParquet) { (sc, sv, hv, h, p) =>
+  s"0.6.0-scala-$sc-spark-$sv-hadoop-$hv" + (if (h) "-with-hive" else "") + (if (p) "-with-parquet" else "")
+}
 
 maintainer := "Andy Petrella" //Docker
 
@@ -65,7 +67,9 @@ resolvers in ThisBuild ++= Seq(
   Resolver.typesafeIvyRepo("snapshots"),
   "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos",
   // docker
-  "softprops-maven" at "http://dl.bintray.com/content/softprops/maven"
+  "softprops-maven" at "http://dl.bintray.com/content/softprops/maven",
+  //spark 1.4
+  "Apache Spark Prerelease" at "https://repository.apache.org/content/repositories/orgapachespark-1092/"
 )
 
 EclipseKeys.skipParents in ThisBuild := false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,22 +46,28 @@ object Dependencies {
   }
 
   val defaultWithHive = sys.props.getOrElse("with.hive", "false").toBoolean
+  val defaultWithParquet = sys.props.getOrElse("with.parquet", "false").toBoolean
+  val parquetList:List[ExclusionRule] =
+    if (!defaultWithParquet) {
+      List(
+        ExclusionRule("com.twitter", "parquet-column"),
+        ExclusionRule("com.twitter", "parquet-hadoop")
+      )
+    } else {
+      Nil
+    }
 
   def sparkHive(v: String) = "org.apache.spark" %% "spark-hive" % v excludeAll(
     ExclusionRule("org.apache.hadoop"),
-    ExclusionRule("org.apache.ivy", "ivy"),
-    ExclusionRule("com.twitter", "parquet-column"),
-    ExclusionRule("com.twitter", "parquet-hadoop")
-    )
+    ExclusionRule("org.apache.ivy", "ivy")
+  ) excludeAll(parquetList:_*)
 
   def sparkRepl(
     v: String) = "org.apache.spark" %% "spark-repl" % v excludeAll ExclusionRule("org.apache.hadoop")
 
   def sparkSQL(v: String) = "org.apache.spark" %% "spark-sql" % v excludeAll(
-    ExclusionRule("org.apache.hadoop"),
-    ExclusionRule("com.twitter", "parquet-column"),
-    ExclusionRule("com.twitter", "parquet-hadoop")
-    )
+    ExclusionRule("org.apache.hadoop")
+  ) excludeAll(parquetList:_*)
 
   val defaultHadoopVersion = sys.props.getOrElse("hadoop.version", "1.0.4")
 

--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -13,6 +13,8 @@ object Shared {
 
   lazy val withHive = SettingKey[Boolean]("x-with-hive")
 
+  lazy val withParquet = SettingKey[Boolean]("x-with-parquet")
+
   lazy val sharedSettings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := defaultScalaVersion,
     sparkVersion := defaultSparkVersion,
@@ -24,6 +26,7 @@ object Shared {
       ("jline", "2.12")
     }),
     withHive := defaultWithHive,
+    withParquet := defaultWithParquet,
     libraryDependencies += guava
   )
 


### PR DESCRIPTION
inject parquet in the release and avoid "no class def found" exceptions

parquet version is a hell when working with external data storage, but when using classical spark workflows it's best keeping the spark's parquet deps in.

(probably) fix for #177 when building a distro like this for example:
```
sbt -Dspark.version=1.4.0 -Dhadoop.version=2.2.0 -Dwith.hive=true -Dwith.parquet=true dist
``` 