### PR TITLE
first cut for #195 w/o ipy or github -- only browser side though

### DIFF
--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -76,13 +76,13 @@
                           </ul>
                         </li>
                         <li class="divider"></li>
-                        <li id="print_preview"><a href="#">Print Preview</a></li>
+                        <!-- <li id="print_preview"><a href="#">Print Preview</a></li> -->
                         <li class="dropdown-submenu"><a href="#">Download as</a>
                             <ul class="dropdown-menu">
                                 <li id="download_snb"><a href="#">Spark Notebook (.snb)</a></li>
                                 <li id="download_scala"><a href="#">Scala</a></li>
-                                <li id="download_html"><a href="#">HTML (.html)</a></li>
-                                <li id="download_rst"><a href="#">reST (.rst)</a></li>
+                                <!-- <li id="download_html"><a href="#">HTML (.html)</a></li>
+                                <li id="download_rst"><a href="#">reST (.rst)</a></li> -->
                                 <li id="download_pdf"><a href="#">PDF (.pdf)</a></li>
                             </ul>
                         </li>

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -5,3 +5,42 @@ mainly to be overridden in profile/static/custom/custom.css
 
 This will always be an empty file in IPython
 */
+@media print {
+  #notebook_name {
+    display: block;
+    font-size: 30px
+  }
+
+  #site {
+    overflow: visible;
+  }
+  #notebook-tachyon-container {
+    display: none;
+  }
+
+  .output_stream {
+    display: none;
+  }
+  .output_collapsed {
+    display: none;
+  }
+
+  div.output_prompt {
+    visibility: hidden;
+  }
+
+  div.input_prompt {
+    visibility: hidden;
+  }
+
+  div.input_area {
+    border: 1px white solid;
+  }
+  .CodeMirror {
+    background: #FFF;
+  }
+
+  .print:last-child {
+    page-break-after: auto;
+  }
+}


### PR DESCRIPTION
cc @mvherweg :-).

The idea is to allow some printing from the browser side, CTRL+P or the menu Download As + PDF will open the print popup in the browser that the user can change to whatever he likes, including PDF!

This is a first cut for 0.6.0, it will probably evolve to include more capabilities later:
* custom CSS (open a dialog box to allow user to tune it) 
* preview (by opening the content to be printed in a new window)