### PR TITLE
clear the init context to get rid of class not def in workers

### DIFF
--- a/conf/scripts/init.sc
+++ b/conf/scripts/init.sc
@@ -7,68 +7,65 @@ import notebook.front.third.d3._
 import notebook.front.widgets.magic._
 import notebook.front.widgets.magic.Implicits._
 import notebook.JsonCodec._
-import notebook.util._
 
 
 import org.apache.spark.{SparkContext, SparkConf}
 import org.apache.spark.SparkContext._
+import org.apache.spark.rdd._
+
+@transient val globalScope = new java.io.Serializable {
+  @transient var execUri = Option(System.getenv("SPARK_EXECUTOR_URI"))
+  @transient var execMemory = Option(System.getenv("SPARK_EXECUTOR_MEMORY"))
+  @transient var sparkHome = Option(System.getenv("SPARK_HOME"))
+  @transient var sparkMaster = Option(System.getenv("MASTER"))
 
 
-@transient var execUri = Option(System.getenv("SPARK_EXECUTOR_URI"))
-@transient var execMemory = Option(System.getenv("SPARK_EXECUTOR_MEMORY"))
-@transient var sparkHome = Option(System.getenv("SPARK_HOME"))
-@transient var sparkMaster = Option(System.getenv("MASTER"))
-
-@transient val addedJars: Array[String] = {
-  val envJars = sys.env.get("ADD_JARS")
-  val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
-  val jars = propJars.orElse(envJars).getOrElse("")
-  notebook.Utils.resolveURIs(jars).split(",").filter(_.nonEmpty)
-}
-
-@transient var jars = (addedJars ++ CustomJars).distinct
-
-@transient val uri = _5C4L4_N0T3800K_5P4RK_HOOK
-
-@transient var conf = new SparkConf().setAll(_5C4L4_N0T3800K_5P4RK_C0NF.toList)
-
-@transient var sparkContext:SparkContext = _
-
-def reset(appName:String=notebookName, lastChanges:(SparkConf=>Unit)=(_:SparkConf)=>()):Unit = {
-  conf = new SparkConf()
-  conf.setMaster(sparkMaster.getOrElse("local[*]"))
-      .setAppName(appName)
-      .setAll(_5C4L4_N0T3800K_5P4RK_C0NF.toList)
-      .set("spark.repl.class.uri", uri)
-
-  execMemory foreach (v => conf.set("spark.executor.memory", v))
-  execUri foreach (v => conf.set("spark.executor.uri", v))
-  sparkHome foreach (v => conf.setSparkHome(v))
-
-  conf.setJars(jars)
-
-  lastChanges(conf)
-
-  if (sparkContext != null) {
-    sparkContext.stop()
+  @transient val addedJars: Array[String] = {
+    val envJars = sys.env.get("ADD_JARS")
+    val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
+    val jars = propJars.orElse(envJars).getOrElse("")
+    notebook.Utils.resolveURIs(jars).split(",").filter(_.nonEmpty)
   }
-  sparkContext = new SparkContext(conf)
-  sparkContext.hadoopConfiguration.set("fs.tachyon.impl", "tachyon.hadoop.TFS")
+
+
+  @transient val uri = _5C4L4_N0T3800K_5P4RK_HOOK
+
+  @transient var conf = new SparkConf().setAll(_5C4L4_N0T3800K_5P4RK_C0NF.toList)
+
+  @transient var jars = (addedJars ++ CustomJars ++ conf.get("spark.jars", ":").split(":")).distinct
+
+  @transient var sparkContext:SparkContext = _
+
+  def reset(appName:String=notebookName, lastChanges:(SparkConf=>Unit)=(_:SparkConf)=>()):Unit = {
+    conf = new SparkConf()
+    conf.setMaster(sparkMaster.getOrElse("local[*]"))
+        .setAppName(appName)
+        .setAll(_5C4L4_N0T3800K_5P4RK_C0NF.toList)
+        .set("spark.repl.class.uri", uri)
+
+    execMemory foreach (v => conf.set("spark.executor.memory", v))
+    execUri foreach (v => conf.set("spark.executor.uri", v))
+    sparkHome foreach (v => conf.setSparkHome(v))
+
+    conf.setJars(jars)
+
+    lastChanges(conf)
+
+    if (sparkContext != null) {
+      sparkContext.stop()
+    }
+    sparkContext = new SparkContext(conf)
+    sparkContext.hadoopConfiguration.set("fs.tachyon.impl", "tachyon.hadoop.TFS")
+  }
+
+
+  val stopSpark:()=>Unit = () => sparkContext.stop()
+
+  def sc:SparkContext = sparkContext
 }
+
+import globalScope.{sparkContext, reset, sc, stopSpark}
 
 reset()
-
-def updateJars(newJars:List[String]) = {
-  jars = (newJars ::: jars.toList).distinct.toArray
-}
-
-def stopSpark() = sparkContext.stop()
-
-@transient implicit val updateSparkContex:SparkContext=>Unit = (sc:SparkContext) => {
-  sparkContext = sc
-}
-
-def sc:SparkContext = sparkContext
-
 
 "init.sc done!"


### PR DESCRIPTION
when defining classes in cell, we often had notebook.util.Utils not found exception, this is now gone by cleaning the serialization context (closure) of the notebooks

it also takes into account the spark.jars property that would have been prealably set in the notebook's metadata.