### PR TITLE
Need file:// prefix to read dataFile on localFS

### DIFF
--- a/notebooks/Tachyon Test.snb
+++ b/notebooks/Tachyon Test.snb
@@ -131,7 +131,7 @@
       "collapsed" : false
     },
     "cell_type" : "code",
-    "source" : "val rdd = sparkContext.textFile(dataFile).cache",
+    "source" : "val rdd = sparkContext.textFile(\"file://\" + dataFile).cache",
     "outputs" : [ ]
   }, {
     "metadata" : { },
@@ -165,7 +165,7 @@
       "collapsed" : false
     },
     "cell_type" : "code",
-    "source" : "import org.apache.spark.storage.StorageLevel._\nval rdd2 = sparkContext.textFile(dataFile).persist(OFF_HEAP)",
+    "source" : "import org.apache.spark.storage.StorageLevel._\nval rdd2 = sparkContext.textFile(\"file://\" + dataFile).persist(OFF_HEAP)",
     "outputs" : [ ]
   }, {
     "metadata" : { },


### PR DESCRIPTION
I got the following error without the prefix

org.apache.hadoop.mapred.InvalidInputException: Input path does not exist: hdfs://localhost:9000/tmp/closes.csv
	at org.apache.hadoop.mapred.FileInputFormat.singleThreadedListStatus(FileInputFormat.java:285)
	at org.apache.hadoop.mapred.FileInputFormat.listStatus(FileInputFormat.java:228)
	at org.apache.hadoop.mapred.FileInputFormat.getSplits(FileInputFormat.java:313)
	at org.apache.spark.rdd.HadoopRDD.getPartitions(HadoopRDD.scala:207)
	at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:219)
	at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:217)
	at scala.Option.getOrElse(Option.scala:120)