### PR TITLE
Typo in log message "cout" => "count"

### DIFF
--- a/app/notebook/server/CalcWebSocketService.scala
+++ b/app/notebook/server/CalcWebSocketService.scala
@@ -100,11 +100,11 @@ class CalcWebSocketService(
         spawnCalculator()
 
       case Register(ws: WebSockWrapper) =>
-        Logger.info(s"Registering web-socket ($ws) in service ${this} (current cout is ${wss.size})")
+        Logger.info(s"Registering web-socket ($ws) in service ${this} (current count is ${wss.size})")
         wss = ws :: wss
 
       case Unregister(ws: WebSockWrapper) =>
-        Logger.info(s"UN-registering web-socket ($ws) in service ${this} (current cout is ${wss.size})")
+        Logger.info(s"UN-registering web-socket ($ws) in service ${this} (current count is ${wss.size})")
         wss = wss.filterNot(_ == ws)
 
       case InterruptCalculator =>


### PR DESCRIPTION
Fix a basic typo in the Akka log messages for Register and Unregister.