### PR TITLE
Fix #343 Allow empty scripts in Playground

### DIFF
--- a/modules/common/src/main/scala/notebook/front/Playground.scala
+++ b/modules/common/src/main/scala/notebook/front/Playground.scala
@@ -24,7 +24,7 @@ trait JsWorld[I, O] extends Widget with IODataConnector[I, O] {
     x => s"'../javascripts/notebook/$x'").mkString("[", ",", "]")
   private lazy val call =
     s"""
-      function(playground, ${scripts.map(_.name).mkString(", ")}) {
+      function(${("playground" :: scripts.map(_.name)).mkString(", ")}) {
         // data ==> data-this (in observable.js's scopedEval) ==> this in JS => { dataId, dataInit, ... }
         // this ==> scope (in observable.js's scopedEval) ==> this.parentElement ==> div.container below (toHtml)
 


### PR DESCRIPTION
In the generated JavaScript function assigned to `call`, a comma should only follow the `playground` argument if `scripts` is non-empty.  This is now accomplished by calling `mkString()` on the concatenation of `"playground"` and the scripts' names, mirroring the approach taken when assigning to the `js` member above.

Verification
------------
I have interactively tested this fix in both Firefox and Chrome using a notebook similar to the "Interacting with JavaScript" section in the README, toggling the second parameter of `Playground` between the `consoleDir` script and `Nil`.  Without the patch, the snippet fails to execute when that parameter is `Nil` (due to the errors documented in #343).  With the patch, it executes successfully regardless of the value of the `scripts` parameter.