### PR TITLE
Added an explicit "." to the call to !! for the :sh feature.

### DIFF
--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -283,7 +283,7 @@ class ReplCalculator(
 
           (`text/plain`, s"""
              |import sys.process._
-             |$ps !!
+             |$ps.!!
               """.stripMargin.trim
           )
 


### PR DESCRIPTION
Otherwise you get a "feature" warning in Scala 2.11 if you use postfix expressions. The alternative is to use the `import scala.language.postfixOps` to enable them, but that seems like overkill in this case. So, I chose to add the "." instead.

Worlds smallest code change in a pull request??
