### PR TITLE
Support Spark 1.5.2

### DIFF
--- a/modules/spark/src/main/scala_2.10/spark-1.5.2/HackSparkILoop.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.5.2/HackSparkILoop.scala
@@ -1,0 +1,174 @@
+package org.apache.spark.repl
+
+import scala.reflect._
+import scala.reflect.api.{Mirror, Universe, TypeCreator}
+import scala.tools.nsc.{io, Properties, Settings, interpreter}
+import scala.tools.nsc.interpreter._
+import scala.tools.nsc.util.ScalaClassLoader._
+import scala.reflect.api.{Mirror, TypeCreator, Universe => ApiUniverse}
+
+import scala.tools.nsc.interpreter._
+
+class HackSparkILoop(out:JPrintWriter) extends SparkILoop(None, out, None) { loop:SparkILoop =>
+  def getMaster(): String = {
+    val master = this.master match {
+      case Some(m) => m
+      case None =>
+        val envMaster = sys.env.get("MASTER")
+        val propMaster = sys.props.get("spark.master")
+        propMaster.orElse(envMaster).getOrElse("local[*]")
+    }
+    master
+  }
+  //override var intp: SparkIMain = _
+
+  // classpath entries added via :cp
+  // CP DOESN'T WORK WITH THIS → var addedClasspath: String = ""
+  //var addedClasspath: String = ""
+  val addedClasspathGS:(() => String, String=>Unit) = {
+    val getter = classOf[SparkILoop].getDeclaredMethods.find(_.getName == "org$apache$spark$repl$SparkILoop$$addedClasspath").get
+    val get = () => getter.invoke(loop).asInstanceOf[String]
+
+    val setter = classOf[SparkILoop].getDeclaredMethods.find(_.getName == "org$apache$spark$repl$SparkILoop$$addedClasspath_$eq").get
+    val set = (s:String) => { setter.invoke(loop, s); ()}
+
+    (get, set)
+  }
+
+  def addCps(jars:List[String]) = {
+    import scala.tools.nsc.util.ClassPath
+    var s:String = addedClasspathGS._1()
+    jars foreach { jar =>
+      val f = scala.tools.nsc.io.File(jar).normalize
+      s = ClassPath.join(s, f.path)
+    }
+    addedClasspathGS._2(s)
+  }
+
+  /** A reverse list of commands to replay if the user requests a :replay */
+  var replayCommandStack: List[String] = Nil
+
+  /** A list of commands to replay if the user requests a :replay */
+  def replayCommands = replayCommandStack.reverse
+
+  /** Record a command for replay should the user request a :replay */
+  def addReplay(cmd: String) = replayCommandStack ::= cmd
+
+  val u: scala.reflect.runtime.universe.type = scala.reflect.runtime.universe
+  val m = u.runtimeMirror(getClass.getClassLoader)
+  def tagOfStaticClass[T: ClassTag]: u.TypeTag[T] =
+    u.TypeTag[T](
+      m,
+      new TypeCreator {
+        def apply[U <: ApiUniverse with Singleton](m: Mirror[U]): U # Type =
+          m.staticClass(classTag[T].runtimeClass.getName).toTypeConstructor.asInstanceOf[U # Type]
+      })
+
+  override def initializeSpark() {
+    /*intp.beQuietDuring {
+      command("""
+         @transient val sc = org.apache.spark.repl.Main.interp.createSparkContext();
+              """)
+      command("import org.apache.spark.SparkContext._")
+    }
+    echo("Spark context available as sc.")*/
+  }
+
+  var in: InteractiveReader = _   // the input stream from which commands come
+
+  /** Tries to create a JLineReader, falling back to SimpleReader:
+   *  unless settings or properties are such that it should start
+   *  with SimpleReader.
+   */
+  // anyway → not used and the spark one hangs with nohup
+  def chooseReader(settings: Settings): InteractiveReader = SimpleReader()
+
+  // runs :load `file` on any files passed via -i
+  def loadFiles(settings: Settings) = settings match {
+    case settings: SparkRunnerSettings =>
+      for (filename <- settings.loadfiles.value) {
+        val cmd = ":load " + filename
+        command(cmd)
+        addReplay(cmd)
+        echo("")
+      }
+    case _ =>
+  }
+
+  def reset() {
+    intp.reset()
+    // unleashAndSetPhase()
+  }
+  def replay() {
+    reset()
+    if (replayCommandStack.isEmpty)
+      echo("Nothing to replay.")
+    else for (cmd <- replayCommands) {
+      echo("Replaying: " + cmd)  // flush because maybe cmd will have its own output
+      command(cmd)
+      echo("")
+    }
+  }
+
+  def process(settings: Settings): Boolean = savingContextLoader {
+
+    if (getMaster() == "yarn-client") System.setProperty("SPARK_YARN_MODE", "true")
+
+    this.settings = settings
+
+    createInterpreter()
+
+    // sets in to some kind of reader depending on environmental cues
+    in ={
+        // some post-initialization
+        chooseReader(settings) match {
+          case x: SparkJLineReader => addThunk(x.consoleReader.postInit) ; x
+          case x                   => x
+        }
+    }
+    lazy val tagOfSparkIMain = tagOfStaticClass[org.apache.spark.repl.SparkIMain]
+    // Bind intp somewhere out of the regular namespace where
+    // we can get at it in generated code.
+    addThunk(intp.quietBind(NamedParam[SparkIMain]("$intp", intp)(tagOfSparkIMain, classTag[SparkIMain])))
+    addThunk({
+      import scala.tools.nsc.io._
+      import Properties.userHome
+      import scala.compat.Platform.EOL
+      val autorun = replProps.replAutorunCode.option flatMap (f => io.File(f).safeSlurp())
+      if (autorun.isDefined) intp.quietRun(autorun.get)
+    })
+
+    addThunk(printWelcome())
+    addThunk(initializeSpark())
+
+    // it is broken on startup; go ahead and exit
+    if (intp.reporter.hasErrors)
+      return false
+
+    // This is about the illusion of snappiness.  We call initialize()
+    // which spins off a separate thread, then print the prompt and try
+    // our best to look ready.  The interlocking lazy vals tend to
+    // inter-deadlock, so we break the cycle with a single asynchronous
+    // message to an actor.
+    if (isAsync) {
+      intp initialize initializedCallback()
+      createAsyncListener() // listens for signal to run postInitialization
+    }
+    else {
+      // ??? intp.getInterpreterClassLoader
+      intp.initializeSynchronous()
+      postInitialization()
+    }
+    // printWelcome()
+
+    loadFiles(settings)
+
+    //try loop()
+    //catch AbstractOrMissingHandler()
+    //finally closeInterpreter()
+
+    true
+  }
+
+
+}

--- a/modules/spark/src/main/scala_2.10/spark-1.5.2/UtilsFromSpark.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.5.2/UtilsFromSpark.scala
@@ -1,0 +1,103 @@
+package notebook
+
+import java.io._
+import java.lang.management.ManagementFactory
+import java.net._
+import java.nio.ByteBuffer
+import java.util.concurrent.{ConcurrentHashMap, Executors, ThreadFactory, ThreadPoolExecutor}
+import java.util.{Locale, Properties, Random, UUID}
+
+import scala.collection.JavaConversions._
+import scala.collection.Map
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+import scala.reflect.ClassTag
+import scala.util.Try
+import scala.util.control.{ControlThrowable, NonFatal}
+
+import com.google.common.io.{ByteStreams, Files}
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import org.apache.commons.lang3.SystemUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
+import org.apache.log4j.PropertyConfigurator
+
+import org.json4s._
+
+import org.apache.spark._
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.serializer.{DeserializationStream, SerializationStream, SerializerInstance}
+
+
+/**
+ * Copied from https://github.com/apache/spark/blob/branch-1.2/core/src/main/scala/org/apache/spark/util/Utils.scala
+ * On Feb 28th, 2015
+ */
+object Utils extends Logging {
+  /**
+   * Whether the underlying operating system is Windows.
+   */
+  val isWindows = SystemUtils.IS_OS_WINDOWS
+
+  /**
+   * Whether the underlying operating system is Mac OS X.
+   */
+  val isMac = SystemUtils.IS_OS_MAC_OSX
+
+  /**
+   * Pattern for matching a Windows drive, which contains only a single alphabet character.
+   */
+  val windowsDrive = "([a-zA-Z])".r
+
+  /**
+   * Format a Windows path such that it can be safely passed to a URI.
+   */
+  def formatWindowsPath(path: String): String = path.replace("\\", "/")
+
+  /**
+   * Indicates whether Spark is currently running unit tests.
+   */
+  def isTesting = {
+    sys.env.contains("SPARK_TESTING") || sys.props.contains("spark.testing")
+  }
+
+  /**
+   * Return a well-formed URI for the file described by a user input string.
+   *
+   * If the supplied path does not contain a scheme, or is a relative path, it will be
+   * converted into an absolute path with a file:// scheme.
+   */
+  def resolveURI(path: String, testWindows: Boolean = false): URI = {
+
+    // In Windows, the file separator is a backslash, but this is inconsistent with the URI format
+    val windows = isWindows || testWindows
+    val formattedPath = if (windows) formatWindowsPath(path) else path
+
+    val uri = new URI(formattedPath)
+    if (uri.getPath == null) {
+      throw new IllegalArgumentException(s"Given path is malformed: $uri")
+    }
+
+    Option(uri.getScheme) match {
+      case Some(windowsDrive(d)) if windows =>
+        new URI("file:/" + uri.toString.stripPrefix("/"))
+      case None =>
+        // Preserve fragments for HDFS file name substitution (denoted by "#")
+        // For instance, in "abc.py#xyz.py", "xyz.py" is the name observed by the application
+        val fragment = uri.getFragment
+        val part = new File(uri.getPath).toURI
+        new URI(part.getScheme, part.getPath, fragment)
+      case Some(other) =>
+        uri
+    }
+  }
+
+  /** Resolve a comma-separated list of paths. */
+  def resolveURIs(paths: String, testWindows: Boolean = false): String = {
+    if (paths == null || paths.trim.isEmpty) {
+      ""
+    } else {
+      paths.split(",").map { p => Utils.resolveURI(p, testWindows) }.mkString(",")
+    }
+  }
+}

--- a/modules/spark/src/main/scala_2.10/spark-1.5.2/notebook/kernel/EvaluationResult.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.5.2/notebook/kernel/EvaluationResult.scala
@@ -1,0 +1,16 @@
+package notebook.kernel
+
+import xml.NodeSeq
+
+/**
+ * Result of evaluating something in the REPL.
+ *
+ * The difference between Incomplete and Failure is Incomplete means
+ * the expression failed to compile whereas Failure means an exception
+ * was thrown during executing the code.
+ */
+sealed abstract class EvaluationResult
+
+case object Incomplete extends EvaluationResult
+case class Failure(stackTrace: String) extends EvaluationResult
+case class Success(result: NodeSeq) extends EvaluationResult

--- a/modules/spark/src/main/scala_2.10/spark-1.5.2/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.5.2/notebook/kernel/Repl.scala
@@ -1,0 +1,315 @@
+package notebook.kernel
+
+import java.io.{StringWriter, PrintWriter, ByteArrayOutputStream}
+import java.net.{URLDecoder, JarURLConnection}
+import java.util.ArrayList
+
+import scala.collection.JavaConversions
+import scala.collection.JavaConversions._
+import scala.xml.{NodeSeq, Text}
+import scala.util.control.NonFatal
+import scala.util.Try
+
+import tools.nsc.Settings
+import tools.nsc.interpreter._
+import tools.nsc.interpreter.Completion.{Candidates, ScalaCompleter}
+import tools.nsc.interpreter.Results.{Incomplete => ReplIncomplete, Success => ReplSuccess, Error}
+
+import tools.jline.console.completer.{ArgumentCompleter, Completer}
+
+import org.apache.spark.repl._
+
+import notebook.front.Widget
+import notebook.util.Match
+import notebook.kernel._
+
+class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
+  val LOG = org.slf4j.LoggerFactory.getLogger(classOf[Repl])
+
+  def this() = this(Nil)
+
+  class MyOutputStream extends ByteArrayOutputStream {
+    var aop: String => Unit = x => ()
+
+    override def write(i: Int): Unit = {
+      // CY: Not used...
+      //      orig.value ! StreamResponse(i.toString, "stdout")
+      super.write(i)
+    }
+
+    override def write(bytes: Array[Byte]): Unit = {
+      // CY: Not used...
+      //      orig.value ! StreamResponse(bytes.toString, "stdout")
+      super.write(bytes)
+    }
+
+    override def write(bytes: Array[Byte], off: Int, length: Int): Unit = {
+      val data = new String(bytes, off, length)
+      aop(data)
+      //      orig.value ! StreamResponse(data, "stdout")
+      super.write(bytes, off, length)
+    }
+  }
+
+
+  private lazy val stdoutBytes = new MyOutputStream
+  private lazy val stdout = new PrintWriter(stdoutBytes)
+
+  private var loop:HackSparkILoop = _
+
+  var classServerUri:Option[String] = None
+
+  val interp:org.apache.spark.repl.SparkIMain = {
+    val settings = new Settings
+
+    settings.embeddedDefaults[Repl]
+
+    if (!compilerOpts.isEmpty) settings.processArguments(compilerOpts, false)
+
+    // fix for #52
+    settings.usejavacp.value = false
+
+
+    // fix for #52
+    val urls: IndexedSeq[String] = {
+      import java.net.URLClassLoader
+      import java.io.File
+      def urls(cl:ClassLoader, acc:IndexedSeq[String]=IndexedSeq.empty):IndexedSeq[String] = {
+        if (cl != null) {
+          val us = if (!cl.isInstanceOf[URLClassLoader]) {
+            acc
+          } else {
+            acc ++ (cl.asInstanceOf[URLClassLoader].getURLs map { u =>
+              val f = new File(u.getFile)
+              URLDecoder.decode(f.getAbsolutePath, "UTF8")
+            })
+          }
+          urls(cl.getParent, us)
+        } else {
+          acc
+        }
+      }
+      val loader = getClass.getClassLoader
+      val gurls = urls(loader).distinct//.filter(!_.contains("logback-classic"))//.filter(!_.contains("sbt/"))
+      gurls
+    }
+
+    val classpath = urls// map {_.toString}
+    settings.classpath.value = classpath.distinct.mkString(java.io.File.pathSeparator)
+
+    //bootclasspath → settings.classpath.isDefault = false → settings.classpath is used
+    settings.bootclasspath.value += scala.tools.util.PathResolver.Environment.javaBootClassPath
+    settings.bootclasspath.value += java.io.File.pathSeparator + settings.classpath.value
+
+    // LOG the classpath
+    // debug the classpath → settings.Ylogcp.value = true
+
+    //val i = new HackIMain(settings, stdout)
+    loop = new HackSparkILoop(stdout)
+
+    loop.addCps(jars)
+
+    loop.process(settings)
+    val i = {
+      val l:HackSparkILoop = loop.asInstanceOf[HackSparkILoop]
+      l.interpreter
+    }
+    //i.initializeSynchronous()
+    classServerUri = Some(i.classServerUri)
+    i.asInstanceOf[org.apache.spark.repl.SparkIMain]
+  }
+
+  private lazy val completion = {
+    //new JLineCompletion(interp)
+    new SparkJLineCompletion(interp)
+  }
+
+  private def scalaToJline(tc: ScalaCompleter): Completer = new Completer {
+    def complete(_buf: String, cursor: Int, candidates: JList[CharSequence]): Int = {
+      val buf   = if (_buf == null) "" else _buf
+      val Candidates(newCursor, newCandidates) = tc.complete(buf, cursor)
+      newCandidates foreach (candidates add _)
+      newCursor
+    }
+  }
+
+  private lazy val argCompletor = {
+    val arg = new ArgumentCompleter(new JLineDelimiter, scalaToJline(completion.completer()))
+    // turns out this is super important a line
+    arg.setStrict(false)
+    arg
+  }
+
+  private lazy val stringCompletor = StringCompletorResolver.completor
+
+  private def getCompletions(line: String, cursorPosition: Int) = {
+    val candidates = new ArrayList[CharSequence]()
+    argCompletor.complete(line, cursorPosition, candidates)
+    candidates map { _.toString } toList
+  }
+
+  /**
+   * Evaluates the given code.  Swaps out the `println` OutputStream with a version that
+   * invokes the given `onPrintln` callback everytime the given code somehow invokes a
+   * `println`.
+   *
+   * Uses compile-time implicits to choose a renderer.  If a renderer cannot be found,
+   * then just uses `toString` on result.
+   *
+   * I don't think this is thread-safe (largely because I don't think the underlying
+   * IMain is thread-safe), it certainly isn't designed that way.
+   *
+   * @param code
+   * @param onPrintln
+   * @return result and a copy of the stdout buffer during the duration of the execution
+   */
+  def evaluate(code: String, onPrintln: String => Unit = _ => ()): (EvaluationResult, String) = {
+    stdout.flush()
+    stdoutBytes.reset()
+
+    // capture stdout if the code the user wrote was a println, for example
+    stdoutBytes.aop = onPrintln
+    val res = Console.withOut(stdoutBytes) {
+      interp.interpret(code)
+    }
+    stdout.flush()
+    stdoutBytes.aop = _ => ()
+
+    val result = res match {
+      case ReplSuccess =>
+        val request:interp.Request = interp.getClass.getMethods.find(_.getName == "prevRequestList").map(_.invoke(interp)).get.asInstanceOf[List[interp.Request]].last
+        //val request:Request = interp.prevRequestList.last
+
+        val lastHandler/*: interp.memberHandlers.MemberHandler*/ = request.handlers.last
+
+        try {
+          val evalValue = if (lastHandler.definesValue) { // This is true for def's with no parameters, not sure that executing/outputting this is desirable
+            // CY: So for whatever reason, line.evalValue attemps to call the $eval method
+            // on the class...a method that does not exist. Not sure if this is a bug in the
+            // REPL or some artifact of how we are calling it.
+            // RH: The above comment may be going stale given the shenanigans I'm pulling below.
+            val line = request.lineRep
+            val renderObjectCode =
+              """object $rendered {
+                |  %s
+                |  val rendered: _root_.notebook.front.Widget = { %s }
+                |  %s
+                |}""".stripMargin.format(
+                  request.importsPreamble,
+                  request.fullPath(lastHandler.definesTerm.get),
+                  request.importsTrailer
+                )
+            if (line.compile(renderObjectCode)) {
+              try {
+                val classLoader = interp.getClass.getMethods.find(_.getName == "classLoader").map(_.invoke(interp)).get.asInstanceOf[java.lang.ClassLoader]
+
+                val renderedClass2 = Class.forName(
+                  line.pathTo("$rendered")+"$", true, classLoader
+                )
+
+                val o = renderedClass2.getDeclaredField(interp.global.nme.MODULE_INSTANCE_FIELD.toString).get()
+
+                def iws(o:Any):NodeSeq = {
+                  val iw = o.getClass.getMethods.find(_.getName == "$iw")
+                  val o2 = iw map { m =>
+                    m.invoke(o)
+                  }
+                  o2 match {
+                    case Some(o3) =>
+                      iws(o3)
+                    case None =>
+                      val r = o.getClass.getDeclaredMethod("rendered").invoke(o)
+                      val h = r.asInstanceOf[Widget].toHtml
+                      h
+                  }
+                }
+                iws(o)
+              } catch {
+                case e =>
+                  e.printStackTrace
+                  LOG.error("Ooops, exception in the cell", e)
+                  <span style="color:red;">Ooops, exception in the cell: {e.getMessage}</span>
+              }
+            } else {
+              // a line like println(...) is technically a val, but returns null for some reason
+              // so wrap it in an option in case that happens...
+              Option(line.call("$result")) map { result => Text(try { result.toString } catch { case e => "Fail to `toString` the result: " + e.getMessage }) } getOrElse NodeSeq.Empty
+            }
+          } else {
+            NodeSeq.Empty
+          }
+
+          Success(evalValue)
+        }
+        catch {
+          case NonFatal(e) =>
+            val ex = new StringWriter()
+            e.printStackTrace(new PrintWriter(ex))
+            Failure(ex.toString)
+        }
+
+      case ReplIncomplete => Incomplete
+      case Error          => Failure(stdoutBytes.toString)
+    }
+
+    (result, stdoutBytes.toString)
+  }
+
+  def addCp(newJars:List[String]) = {
+    val requests = interp.getClass.getMethods.find(_.getName == "prevRequestList").map(_.invoke(interp)).get.asInstanceOf[List[interp.Request]]
+
+    val prevCode = requests.map(_.originalLine)
+    val jarList = newJars:::jars
+    val r = new Repl(compilerOpts, jarList)
+    (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
+  }
+
+  def complete(line: String, cursorPosition: Int): (String, Seq[Match]) = {
+    def literalCompletion(arg: String) = {
+      val LiteralReg = """.*"([\w/]+)""".r
+      arg match {
+        case LiteralReg(literal) => Some(literal)
+        case _ => None
+      }
+    }
+
+    // CY: Don't ask to explain why this works. Look at JLineCompletion.JLineTabCompletion.complete.mkDotted
+    // The "regularCompletion" path is the only path that is (likely) to succeed
+    // so we want access to that parsed version to pull out the part that was "matched"...
+    // ...just...trust me.
+    val delim = argCompletor.getDelimiter
+    val list = delim.delimit(line, cursorPosition)
+    val bufferPassedToCompletion = list.getCursorArgument
+    val actCursorPosition = list.getArgumentPosition
+    val parsed = Parsed.dotted(bufferPassedToCompletion, actCursorPosition) // withVerbosity verbosity
+    val matchedText = bufferPassedToCompletion.takeRight(actCursorPosition - parsed.position)
+
+    literalCompletion(bufferPassedToCompletion) match {
+      case Some(literal) =>
+        // strip any leading quotes
+        stringCompletor.complete(literal)
+      case None =>
+        val candidates = getCompletions(line, cursorPosition)
+
+        (matchedText, if (candidates.size > 0 && candidates.head.isEmpty) {
+          List()
+        } else {
+          candidates.map(Match(_))
+        })
+    }
+  }
+
+  def objectInfo(line: String, position:Int): Seq[String] = {
+    // CY: The REPL is stateful -- it isn't until you ask to complete
+    // the thing twice does it give you the method signature (i.e. you
+    // hit tab twice).  So we simulate that here... (nutty, I know)
+    getCompletions(line, position)
+    val candidates = getCompletions(line, position)
+
+    if (candidates.size >= 2 && candidates.head.isEmpty) {
+      candidates.tail
+    } else {
+      Seq.empty
+    }
+  }
+}

--- a/modules/spark/src/main/scala_2.10/spark-1.5.2/notebook/kernel/StringCompletorResolver.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.5.2/notebook/kernel/StringCompletorResolver.scala
@@ -1,0 +1,12 @@
+package notebook.kernel
+
+//import org.clapper.util.classutil.ClassUtil
+import notebook.util.StringCompletor
+
+object StringCompletorResolver {
+  lazy val completor = {
+    val className = "notebook.kernel.TestStringCompletor"
+    //ClassUtil.instantiateClass(className).asInstanceOf[StringCompletor]
+      Class.forName(className).getConstructor().newInstance().asInstanceOf[StringCompletor]
+  }
+}

--- a/modules/spark/src/main/scala_2.10/spark-1.5.2/notebook/kernel/TestStringCompletor.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.5.2/notebook/kernel/TestStringCompletor.scala
@@ -1,0 +1,7 @@
+package notebook.kernel
+
+import notebook.util.{Match, StringCompletor}
+
+class TestStringCompletor extends StringCompletor {
+  def complete(stringToComplete: String) = (stringToComplete, if (stringToComplete.toLowerCase.startsWith("usa")) Seq("usacpi", "usangdp").map(Match(_, Map("Location" -> "InflationEstimate/master"))) else Seq())
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,6 +79,7 @@ object Dependencies {
     ExclusionRule("org.apache.ivy", "ivy"),
     ExclusionRule("javax.servlet", "servlet-api"),
     ExclusionRule("org.mortbay.jetty", "servlet-api"),
+    // P.S. Need to comment this out for spark 1.5.2 work with Hive+parquet in CDH 5.4.4+ (hadoop 2.6.0)    
     ExclusionRule("com.twitter", "parquet-hadoop-bundle")
   ) excludeAll(parquetList:_*)
 


### PR DESCRIPTION
- simply copied over the `modules/spark/src/main/scala_2.10/spark-1.5.1` into `modules/spark/src/main/scala_2.10/spark-1.5.2`. works fine.
- rc2 should work by simply adding repo url into resolvers.
- add a note, on how to workaround `hive+parquet` to work in `spark 1.5.2 with CDH 5.4.4+`

@jarutis @andypetrella 
