### PR TITLE
Pivot chart with toggleable controls

### DIFF
--- a/app/assets/javascripts/notebook/magic/pivotChart.coffee
+++ b/app/assets/javascripts/notebook/magic/pivotChart.coffee
@@ -77,6 +77,9 @@ define([
         toggleOptionsBtn.click ->
           $(container).find(".pvtUi").toggleClass("pivot-controls-hidden")
         $(container).prepend(toggleOptionsBtn)
+        # collapse all pivotchart controls in report mode
+        report_mode = $("body[data-presentation='report']").length > 0
+        $(".pvtUi").addClass("pivot-controls-hidden") if report_mode
 
       dataO.subscribe( (newData) =>
         plotThat(newData)

--- a/app/assets/javascripts/notebook/magic/pivotChart.coffee
+++ b/app/assets/javascripts/notebook/magic/pivotChart.coffee
@@ -73,6 +73,11 @@ define([
       plotThat = (data) =>
         $(container).pivotUI(data, pivotOptions)
 
+        toggleOptionsBtn = $("<a class='pvtUi-toggle-controls-btn'>show/hide options</a>")
+        toggleOptionsBtn.click ->
+          $(container).find(".pvtUi").toggleClass("pivot-controls-hidden")
+        $(container).prepend(toggleOptionsBtn)
+
       dataO.subscribe( (newData) =>
         plotThat(newData)
       )

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -63,3 +63,12 @@ This will always be an empty file in IPython
 .rendered_html tr, .rendered_html th, .rendered_html td {
   border: 1px solid #aaa;
 }
+
+/* pivot chart */
+.pivot-controls-hidden .pvtVals, .pivot-controls-hidden .pvtRenderer, .pivot-controls-hidden .pvtAxisContainer {
+  visibility: hidden;
+  display: none;
+}
+table.pivot-controls-hidden, .pivot-controls-hidden > tbody > tr, .pivot-controls-hidden > tbody > tr > td {
+  border: none ! important;
+}


### PR DESCRIPTION
@andypetrella 

in report more the controls are collapsed by default.

---

looks like this:

<img width="762" alt="screen shot 2015-11-26 at 23 12 33" src="https://cloud.githubusercontent.com/assets/213426/11430702/4148e6f8-9493-11e5-8862-9dd54403aa22.png">
