### PR TITLE
Show SparkUI link

### DIFF
--- a/modules/common/src/main/scala/notebook/front/gadgets/SparkMonitor.scala
+++ b/modules/common/src/main/scala/notebook/front/gadgets/SparkMonitor.scala
@@ -10,8 +10,9 @@ import org.apache.spark.scheduler.StageInfo
 
 import play.api.libs.json._
 
+import notebook.util.Logging
 
-class SparkMonitor(sparkContext:SparkContext, checkInterval:Long = 1000) {
+class SparkMonitor(sparkContext:SparkContext, checkInterval:Long = 1000) extends Logging {
 
   val connection = notebook.JSBus.createConnection("jobsProgress")
 
@@ -39,8 +40,10 @@ class SparkMonitor(sparkContext:SparkContext, checkInterval:Long = 1000) {
         }
         appUIAddress
       } catch {
-        case e =>
-          // add log I guess
+        // reflective methods above may throw: SecurityException | ReflectiveOperationException | IllegalArgumentException
+        // these are all RuntimeException, so at least catch this instead of catching any Exception
+        case e: RuntimeException =>
+          logWarn("Unable to determine URL for sparkUI", e)
           None
       }
   }

--- a/public/javascripts/notebook/job_progress.js
+++ b/public/javascripts/notebook/job_progress.js
@@ -13,9 +13,17 @@ define([
       // move progress node to body, to enable absolute positioning
       var pies = d3.select("#progress-pies")
       $(pies.node()).appendTo("body");
+      $("#progress-pies").append($("<div id='progress-bars'/>")).append("<div id='spark-ui-link' />");
+
+      var updateSparkUiLink = function(sparkUi){
+        if (sparkUi != "") {
+          var sparkUiLink = $("<a href='" + sparkUi + "' id='spark-ui-link' target='_blank'>SparkUI</a>")
+          $("#spark-ui-link").replaceWith(sparkUiLink);
+        }
+      };
 
       // setup the progress chart
-      var svg = dimple.newSvg("#progress-pies", 100, 400);
+      var svg = dimple.newSvg("#progress-bars", 100, 400);
       var myChart = new dimple.chart(svg, []);
       var xAxis = myChart.addPctAxis("x", "completed");
       xAxis.title = "% completed";
@@ -33,7 +41,12 @@ define([
       var sum = function(items){ return _.reduce(items, function(memo, p){ return memo + p} , 0) };
 
       var olderProgresses = [];
-      progress.subscribe(function(jobsProgress) {
+      progress.subscribe(function(status) {
+        var jobsProgress = status.jobsStatus;
+        var sparkUi = status.sparkUi;
+
+        updateSparkUiLink(sparkUi);
+
         // redraw only if changed
         var totalCompletions = function(ps) { return sum(_.pluck(ps, 'completed')); };
         if (totalCompletions(olderProgresses) == totalCompletions(jobsProgress)) {


### PR DESCRIPTION
- support YARN mode, use `export YARN_JOB_PROXY_URL="http://yarn.company.com/proxy/"` to enable this
- spark standalone should work similarly when needed...

depends on #395 , so see only [this commit](https://github.com/andypetrella/spark-notebook/commit/6446b900f9938b2fbb3f4ab5aef0d4ede4955bf7)

@andypetrella 