### PR TITLE
Initiate notebook recomputation if action=recompute_now in url

### DIFF
--- a/public/ipython/custom/custom.js
+++ b/public/ipython/custom/custom.js
@@ -157,4 +157,12 @@ require([
             $("#notebook-container").removeClass("container").addClass("container-fluid");
         }
     });
+    events.on("kernel_ready.Kernel", function(){
+        // recompute the notebook if 'action=recompute_now' is in URL
+        var url = window.location.href;
+        if (url.indexOf("recompute_now") != -1) {
+            console.log("Now running all cells in notebook (recompute_now)");
+            IPython.notebook.execute_all_cells();
+        }
+    });
 });


### PR DESCRIPTION
makes URLs like `/notebooks/sql/DataFrame.snb?presentation=report&action=recompute_now` to automatically launch notebook recomputation (Run all cells).

If needed, scheduling could be done by some browser plugin for now.

is `kernel_ready.Kernel` the right event to wait for? works fine for me.

@andypetrella 