### PR TITLE
PivotUI: top-align the selected dimensions

### DIFF
--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -72,3 +72,7 @@ This will always be an empty file in IPython
 table.pivot-controls-hidden, .pivot-controls-hidden > tbody > tr, .pivot-controls-hidden > tbody > tr > td {
   border: none ! important;
 }
+.pvtUi td.pvtAxisContainer.pvtRows {
+  /* align selected dimensions on the top, so easier to control them when there are many rows in table */
+  vertical-align: top;
+}


### PR DESCRIPTION
`age` is now on top, making it easier to manipulate. especially if there's lots of rows (it was in the middle)

<img width="735" alt="screen shot 2015-11-30 at 16 34 51" src="https://cloud.githubusercontent.com/assets/213426/11474405/9c830d88-9780-11e5-9191-bcbdaa791606.png">


cc @andypetrella