### PR TITLE
support %% in the deps. Needs to support spark version now...

### DIFF
--- a/modules/common/src/main/scala-2.10/notebook/util/Deps.scala
+++ b/modules/common/src/main/scala-2.10/notebook/util/Deps.scala
@@ -5,16 +5,20 @@ import sbt._
 import scala.util.Try
 
 object Deps extends java.io.Serializable {
-  private val PATTERN_MODULEID_1 = """^([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
-  private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
+  private val PATTERN_MODULEID_1 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
+  private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
   private val PATTERN_COORDINATE_1 = """^([^:/]+)[:/]([^:]+):([^:]+)$""".r
 
   def parseInclude(s: String): Option[ModuleID] = {
     s.headOption.filter(_ != '-').map(_ => s.dropWhile(_ == '+').trim).flatMap { line =>
       line.replaceAll("\"", "").trim match {
-        case PATTERN_MODULEID_1(g, a, v) =>
+        case PATTERN_MODULEID_1(g, "%", a, v) =>
+          Some(g %% a % v % "compile")
+        case PATTERN_MODULEID_1(g, "", a, v) =>
           Some(g % a % v % "compile")
-        case PATTERN_MODULEID_2(g, a, v, p) =>
+        case PATTERN_MODULEID_2(g, "%", a, v, p) =>
+          Some(g %% a % v % p)
+        case PATTERN_MODULEID_2(g, "", a, v, p) =>
           Some(g % a % v % p)
         case PATTERN_COORDINATE_1(g, a, v) =>
           Some(g % a % v % "compile")
@@ -33,8 +37,10 @@ object Deps extends java.io.Serializable {
   def parseExclude(s: String): Option[ExclusionRule] = {
     s.headOption.filter(_ == '-').map(_ => s.dropWhile(_ == '-').trim).flatMap { line =>
       line.replaceAll("\"", "") match {
-        case PATTERN_MODULEID_1(g, a, v) =>
+        case PATTERN_MODULEID_1(g, "", a, v) =>
           Some(ExclusionRule(organization = parsePartialExclude(g), name = parsePartialExclude(a)))
+        case PATTERN_MODULEID_1(g, "%", a, v) =>
+          Some(ExclusionRule(organization = parsePartialExclude(g), name = a+"_2.10"))
         case PATTERN_COORDINATE_1(g, a, v) =>
           Some(ExclusionRule(organization = parsePartialExclude(g), name = parsePartialExclude(a)))
         case _ =>

--- a/modules/common/src/main/scala-2.11/notebook/util/Deps.scala
+++ b/modules/common/src/main/scala-2.11/notebook/util/Deps.scala
@@ -112,23 +112,27 @@ object ArtifactSelector {
 }
 
 object Deps extends java.io.Serializable {
-   val logger = org.slf4j.LoggerFactory.getLogger("Aether downloads")
+  val logger = org.slf4j.LoggerFactory.getLogger("Aether downloads")
 
-   type ArtifactPredicate = PartialFunction[(ArtifactMD, Set[ArtifactMD]), Boolean]
+  type ArtifactPredicate = PartialFunction[(ArtifactMD, Set[ArtifactMD]), Boolean]
 
-  private val PATTERN_MODULEID_1 = """^([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
-  private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
+  private val PATTERN_MODULEID_1 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
+  private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
   private val PATTERN_COORDINATE_1 = """^([^:/]+)[:/]([^:]+):([^:]+)$""".r
 
   def parseInclude(s:String):Option[ArtifactMD] = {
     s.headOption.filter(_ != '-').map(_ => s.dropWhile(_=='+').trim).flatMap { line =>
       line.replaceAll("\"", "").trim match {
-        case PATTERN_MODULEID_1(g, a, v) =>
+        case PATTERN_MODULEID_1(g, "%", a, v) =>
+          Some(ArtifactMD(g, a+"_2.11", v))
+        case PATTERN_MODULEID_1(g, "", a, v) =>
           Some(ArtifactMD(g, a, v))
-        case PATTERN_MODULEID_2(g, a, v, p) =>
+        case PATTERN_MODULEID_2(g, "%", a, v, p) =>
+          Some(ArtifactMD(g, a+"_2.11", v, Some(p)))
+        case PATTERN_MODULEID_2(g, "", a, v, p) =>
           Some(ArtifactMD(g, a, v, Some(p)))
         case PATTERN_COORDINATE_1(g, a, v) =>
-          Some(ArtifactMD(g, a, v))
+          Some(g % a % v % "compile")
         case _ =>
           None
       }
@@ -143,8 +147,10 @@ object Deps extends java.io.Serializable {
   def parseExclude(s:String):Option[ArtifactSelector] = {
     s.headOption.filter(_ == '-').map(_ => s.dropWhile(_=='-').trim).flatMap { line =>
       line.replaceAll("\"", "") match {
-        case PATTERN_MODULEID_1(g, a, v) =>
+        case PATTERN_MODULEID_1(g, "", a, v) =>
           Some(ArtifactSelector(parsePartialExclude(g), parsePartialExclude(a), parsePartialExclude(v)))
+        case PATTERN_MODULEID_1(g, "%", a, v) =>
+          Some(ArtifactSelector(parsePartialExclude(g), Some(a+"_2.11"), parsePartialExclude(v)))
         case PATTERN_COORDINATE_1(g, a, v) =>
           Some(ArtifactSelector(parsePartialExclude(g), parsePartialExclude(a), parsePartialExclude(v)))
         case _ =>


### PR DESCRIPTION
This PR brings support for `%%` in the deps so that the right scala version is picked -- adding the `_2.10` or `_2.11` to the artifact name