### PR TITLE
Spark version deps

### DIFF
--- a/modules/common/src/main/scala-2.10/notebook/util/Deps.scala
+++ b/modules/common/src/main/scala-2.10/notebook/util/Deps.scala
@@ -9,19 +9,24 @@ object Deps extends java.io.Serializable {
   private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
   private val PATTERN_COORDINATE_1 = """^([^:/]+)[:/]([^:]+):([^:]+)$""".r
 
+  def includeSparkVersion(v:String) = v match {
+    case "_" => notebook.BuildInfo.xSparkVersion
+    case x   => x
+  }
+
   def parseInclude(s: String): Option[ModuleID] = {
     s.headOption.filter(_ != '-').map(_ => s.dropWhile(_ == '+').trim).flatMap { line =>
       line.replaceAll("\"", "").trim match {
         case PATTERN_MODULEID_1(g, "%", a, v) =>
-          Some(g %% a % v % "compile")
+          Some(g %% a % includeSparkVersion(v) % "compile")
         case PATTERN_MODULEID_1(g, "", a, v) =>
-          Some(g % a % v % "compile")
+          Some(g % a % includeSparkVersion(v) % "compile")
         case PATTERN_MODULEID_2(g, "%", a, v, p) =>
-          Some(g %% a % v % p)
+          Some(g %% a % includeSparkVersion(v) % p)
         case PATTERN_MODULEID_2(g, "", a, v, p) =>
-          Some(g % a % v % p)
+          Some(g % a % includeSparkVersion(v) % p)
         case PATTERN_COORDINATE_1(g, a, v) =>
-          Some(g % a % v % "compile")
+          Some(g % a % includeSparkVersion(v) % "compile")
         case _ =>
           None
       }

--- a/modules/common/src/main/scala-2.10/notebook/util/Deps.scala
+++ b/modules/common/src/main/scala-2.10/notebook/util/Deps.scala
@@ -5,16 +5,20 @@ import sbt._
 import scala.util.Try
 
 object Deps extends java.io.Serializable {
-  private val PATTERN_MODULEID_1 = """^([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
-  private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
+  private val PATTERN_MODULEID_1 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
+  private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
   private val PATTERN_COORDINATE_1 = """^([^:/]+)[:/]([^:]+):([^:]+)$""".r
 
   def parseInclude(s: String): Option[ModuleID] = {
     s.headOption.filter(_ != '-').map(_ => s.dropWhile(_ == '+').trim).flatMap { line =>
       line.replaceAll("\"", "").trim match {
-        case PATTERN_MODULEID_1(g, a, v) =>
+        case PATTERN_MODULEID_1(g, "%", a, v) =>
+          Some(g %% a % v % "compile")
+        case PATTERN_MODULEID_1(g, "", a, v) =>
           Some(g % a % v % "compile")
-        case PATTERN_MODULEID_2(g, a, v, p) =>
+        case PATTERN_MODULEID_2(g, "%", a, v, p) =>
+          Some(g %% a % v % p)
+        case PATTERN_MODULEID_2(g, "", a, v, p) =>
           Some(g % a % v % p)
         case PATTERN_COORDINATE_1(g, a, v) =>
           Some(g % a % v % "compile")
@@ -33,8 +37,10 @@ object Deps extends java.io.Serializable {
   def parseExclude(s: String): Option[ExclusionRule] = {
     s.headOption.filter(_ == '-').map(_ => s.dropWhile(_ == '-').trim).flatMap { line =>
       line.replaceAll("\"", "") match {
-        case PATTERN_MODULEID_1(g, a, v) =>
+        case PATTERN_MODULEID_1(g, "", a, v) =>
           Some(ExclusionRule(organization = parsePartialExclude(g), name = parsePartialExclude(a)))
+        case PATTERN_MODULEID_1(g, "%", a, v) =>
+          Some(ExclusionRule(organization = parsePartialExclude(g), name = a+"_2.10"))
         case PATTERN_COORDINATE_1(g, a, v) =>
           Some(ExclusionRule(organization = parsePartialExclude(g), name = parsePartialExclude(a)))
         case _ =>

--- a/modules/common/src/main/scala-2.11/notebook/util/Deps.scala
+++ b/modules/common/src/main/scala-2.11/notebook/util/Deps.scala
@@ -120,19 +120,24 @@ object Deps extends java.io.Serializable {
   private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
   private val PATTERN_COORDINATE_1 = """^([^:/]+)[:/]([^:]+):([^:]+)$""".r
 
+  def includeSparkVersion(v:String) = v match {
+    case "_" => notebook.BuildInfo.xSparkVersion
+    case x   => x
+  }
+
   def parseInclude(s:String):Option[ArtifactMD] = {
     s.headOption.filter(_ != '-').map(_ => s.dropWhile(_=='+').trim).flatMap { line =>
       line.replaceAll("\"", "").trim match {
         case PATTERN_MODULEID_1(g, "%", a, v) =>
-          Some(ArtifactMD(g, a+"_2.11", v))
+          Some(ArtifactMD(g, a+"_2.11", includeSparkVersion(v)))
         case PATTERN_MODULEID_1(g, "", a, v) =>
-          Some(ArtifactMD(g, a, v))
+          Some(ArtifactMD(g, a, includeSparkVersion(v)))
         case PATTERN_MODULEID_2(g, "%", a, v, p) =>
-          Some(ArtifactMD(g, a+"_2.11", v, Some(p)))
+          Some(ArtifactMD(g, a+"_2.11", includeSparkVersion(v), Some(p)))
         case PATTERN_MODULEID_2(g, "", a, v, p) =>
-          Some(ArtifactMD(g, a, v, Some(p)))
+          Some(ArtifactMD(g, a, includeSparkVersion(v), Some(p)))
         case PATTERN_COORDINATE_1(g, a, v) =>
-          Some(g % a % v % "compile")
+          Some(ArtifactMD(g, a, includeSparkVersion(v)))
         case _ =>
           None
       }

--- a/modules/common/src/main/scala-2.11/notebook/util/Deps.scala
+++ b/modules/common/src/main/scala-2.11/notebook/util/Deps.scala
@@ -112,23 +112,27 @@ object ArtifactSelector {
 }
 
 object Deps extends java.io.Serializable {
-   val logger = org.slf4j.LoggerFactory.getLogger("Aether downloads")
+  val logger = org.slf4j.LoggerFactory.getLogger("Aether downloads")
 
-   type ArtifactPredicate = PartialFunction[(ArtifactMD, Set[ArtifactMD]), Boolean]
+  type ArtifactPredicate = PartialFunction[(ArtifactMD, Set[ArtifactMD]), Boolean]
 
-  private val PATTERN_MODULEID_1 = """^([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
-  private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
+  private val PATTERN_MODULEID_1 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
+  private val PATTERN_MODULEID_2 = """^([^%\s]+)\s*%(%?)\s*([^%\s]+)\s*%\s*([^%\s]+)\s*%\s*([^%\s]+)$""".r
   private val PATTERN_COORDINATE_1 = """^([^:/]+)[:/]([^:]+):([^:]+)$""".r
 
   def parseInclude(s:String):Option[ArtifactMD] = {
     s.headOption.filter(_ != '-').map(_ => s.dropWhile(_=='+').trim).flatMap { line =>
       line.replaceAll("\"", "").trim match {
-        case PATTERN_MODULEID_1(g, a, v) =>
+        case PATTERN_MODULEID_1(g, "%", a, v) =>
+          Some(ArtifactMD(g, a+"_2.11", v))
+        case PATTERN_MODULEID_1(g, "", a, v) =>
           Some(ArtifactMD(g, a, v))
-        case PATTERN_MODULEID_2(g, a, v, p) =>
+        case PATTERN_MODULEID_2(g, "%", a, v, p) =>
+          Some(ArtifactMD(g, a+"_2.11", v, Some(p)))
+        case PATTERN_MODULEID_2(g, "", a, v, p) =>
           Some(ArtifactMD(g, a, v, Some(p)))
         case PATTERN_COORDINATE_1(g, a, v) =>
-          Some(ArtifactMD(g, a, v))
+          Some(g % a % v % "compile")
         case _ =>
           None
       }
@@ -143,8 +147,10 @@ object Deps extends java.io.Serializable {
   def parseExclude(s:String):Option[ArtifactSelector] = {
     s.headOption.filter(_ == '-').map(_ => s.dropWhile(_=='-').trim).flatMap { line =>
       line.replaceAll("\"", "") match {
-        case PATTERN_MODULEID_1(g, a, v) =>
+        case PATTERN_MODULEID_1(g, "", a, v) =>
           Some(ArtifactSelector(parsePartialExclude(g), parsePartialExclude(a), parsePartialExclude(v)))
+        case PATTERN_MODULEID_1(g, "%", a, v) =>
+          Some(ArtifactSelector(parsePartialExclude(g), Some(a+"_2.11"), parsePartialExclude(v)))
         case PATTERN_COORDINATE_1(g, a, v) =>
           Some(ArtifactSelector(parsePartialExclude(g), parsePartialExclude(a), parsePartialExclude(v)))
         case _ =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val akkaSlf4j = akkaGroup %% "akka-slf4j" % akkaVersion
 
   val scala_2_1X = "2\\.1([0-9])\\.[0-9]+.*".r
-  val spark_1_X = "1\\.([0-9]+)\\.([0-9]+).*".r
+  val spark_1_X = "[a-zA-Z]1\\.([0-9]+)\\.([0-9]+).*".r
   val defaultSparkVersion = sys.props.getOrElse("spark.version", "1.5.1")
   val defaultScalaVersion = sys.props.getOrElse("scala.version", "2.10.4") match {
     case x@scala_2_1X("0") => x


### PR DESCRIPTION
This PR which relies on #406 too is adding support for spark version in the custom deps:

So now we can define a deps like this:
```
"org.apache.spark %% spark-streaming-kafka % _" 
```
which will result in
```
"org.apache.spark %% spark-streaming-kafka_2.10 % 1.6.0" 
```
if scala 2.10 and spark 1.6.0 are used in the running notebook.