### PR TITLE
Add WebHDFS based CSV downloader

### DIFF
--- a/modules/common/src/main/post-df/DownloadCsv.scala
+++ b/modules/common/src/main/post-df/DownloadCsv.scala
@@ -1,0 +1,73 @@
+package notebook.front.widgets
+
+import notebook.front._
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.DataFrame
+
+case class DownloadCsv(df: DataFrame, webHdfsUserName: String = "hive") extends Widget {
+  val log = org.slf4j.LoggerFactory.getLogger("SparkInfo")
+
+  lazy val toHtml = {
+    val link = SpreadsheetOutput.downloadCsv(df, webHdfsUserName = webHdfsUserName)
+    <div class="download-csv">
+      <a target="_blank" href={link}>Download here</a>
+    </div>
+  }
+}
+
+object SpreadsheetOutput {
+  implicit class DataFrameWithSpreadsheetOutput(df: DataFrame) {
+    def downloadCsv() = DownloadCsv(df)
+  }
+
+  implicit class SparkContextWithFsMerge(sc: SparkContext) {
+    def renameFile(src: String, dest: String): Boolean = {
+      // based on http://stackoverflow.com/a/31188767
+      val hadoopConfig = sc.hadoopConfiguration
+      val fs = FileSystem.get(hadoopConfig)
+      val srcPath = new Path(src)
+      val dstPath = new Path(dest)
+      require(fs.exists(srcPath), !fs.exists(dstPath))
+
+      val deleteSource = true
+      // fs.rename should be safer than FileUtil.copyMerge, as it do not put pressure on master
+      fs.rename(srcPath, dstPath)
+    }
+  }
+
+  protected def tmpFileName() = s"/tmp/df-export-${java.util.UUID.randomUUID.toString}"
+
+  def saveAsCsv(df: DataFrame, fileName: String) = {
+    df.write
+      .format("com.databricks.spark.csv")
+      .option("header", "true")
+      .save(fileName)
+  }
+
+  /**
+    * @param hdfsPath - like /user/someuser/someFileName
+    */
+  def webHdfsDownloadLink(hdfsPath: String, userName: String = "hive") = {
+    // operations described at https://goo.gl/i0bt6m
+    sys.env.get("WEB_HDFS_URL") match {
+      case Some(webHdfsHost) =>
+        val webHdfs = s"${webHdfsHost}/webhdfs/v1"
+        s"${webHdfs}${hdfsPath}?user.name=${userName}&op=open"
+      case _ =>
+        s"hdfs://${hdfsPath}"
+    }
+  }
+
+  def downloadCsv(df: DataFrame, fileName: String = "download.csv", webHdfsUserName: String = "hive"): String = {
+    val temporaryFileName = s"${tmpFileName()}/$fileName"
+
+    // save as regular hadoop dir with one part-00000 file
+    val temporaryDirName = s"${temporaryFileName}-tmpdir"
+    saveAsCsv(df.coalesce(1), temporaryDirName)
+
+    // merge part-00000 into a one file
+    df.sqlContext.sparkContext.renameFile(s"${temporaryDirName}/part-00000", temporaryFileName)
+    webHdfsDownloadLink(temporaryFileName, webHdfsUserName)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
   val scala_2_1X = "2\\.1([0-9])\\.[0-9]+.*".r
   val spark_1_X = "[a-zA-Z]*1\\.([0-9]+)\\.([0-9]+).*".r
   val defaultSparkVersion = sys.props.getOrElse("spark.version", "1.5.1")
+  val sparkVersionTuple = defaultSparkVersion match { case extractVs(v, m, p) =>  (v.toInt, m.toInt, p.toInt)}
   val defaultScalaVersion = sys.props.getOrElse("scala.version", "2.10.4") match {
     case x@scala_2_1X("0") => x
     case x@scala_2_1X("1") => defaultSparkVersion match {
@@ -84,10 +85,8 @@ object Dependencies {
     ExclusionRule("org.mortbay.jetty", "servlet-api")
   ) excludeAll(parquetList:_*) excludeAll(
     {
-      val sparkVersion = defaultSparkVersion match { case extractVs(v, m, p) =>  (v.toInt, m.toInt, p.toInt)}
-      val hadoopVersion = defaultHadoopVersion match { case extractVs(v, m, p) => (v.toInt, m.toInt, p.toInt)}
       import scala.math.Ordering.Implicits._
-      if (sparkVersion >= (1, 5, 2)) {
+      if (sparkVersionTuple >= (1, 5, 2)) {
         Nil
       } else {
         List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -103,6 +103,13 @@ object Dependencies {
     ExclusionRule("org.apache.hadoop")
   ) excludeAll(parquetList:_*)
 
+  def sparkCSV: Seq[ModuleID] = {
+    import scala.math.Ordering.Implicits._
+    if (sparkVersionTuple >= (1, 3, 0)) {
+      Seq("com.databricks" %% "spark-csv" % "1.3.0")
+    } else Nil
+  }
+
   def hadoopClient(v: String) = "org.apache.hadoop" % "hadoop-client" % v excludeAll(
     ExclusionRule("org.apache.commons", "commons-exec"),
     ExclusionRule("commons-codec", "commons-codec"),

--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -88,6 +88,7 @@ object Shared {
         sparkCore(sv),
         sparkYarn(sv),
         sparkSQL(sv),
+        "com.databricks" %% "spark-csv" % "1.3.0",
         hadoopClient(hv),
         jets3tVersion,
         commonsCodec

--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -88,12 +88,10 @@ object Shared {
         sparkCore(sv),
         sparkYarn(sv),
         sparkSQL(sv),
-        "com.databricks" %% "spark-csv" % "1.3.0",
         hadoopClient(hv),
         jets3tVersion,
         commonsCodec
-      ) ++
-          (
+      ) ++ sparkCSV ++ (
             if (!v.startsWith("2.10")) {
               // in 2.11
               //Boot.scala → HttpServer → eclipse


### PR DESCRIPTION
Works like this: 
- save CSV to hdfs, reducing to a single file named `download.csv`
- and then produce a link for downloading:
  * via WebHDFS if `WEB_HDFS_URL` environment variable is set (i.e. `WEB_HDFS_URL="http://some-company:some-port"`)
  * or simply `hdfs:///some-hdfs-path` otherwise

Would this make sense to be part of `spark-notebook` ?

some more complex alternatives or future additions could be:
- proxying hdfs file via `spark-notebook` (consumes resources right?)
- detecting `hdfs:///some-hdfs-path` link in output, and automatically formatting it as a link

@andypetrella 


<img width="660" alt="screen shot 2015-12-02 at 19 15 32" src="https://cloud.githubusercontent.com/assets/213426/11538137/307f91ce-9929-11e5-80c8-a1d339da2f85.png">
