### PR TITLE
Make loging less verbose and configurable

### DIFF
--- a/app/notebook/NBSerializer.scala
+++ b/app/notebook/NBSerializer.scala
@@ -226,9 +226,9 @@ object NBSerializer {
   implicit val notebookFormat = Json.format[Notebook]
 
   def fromJson(json: JsValue): Notebook = {
-    println("\r\n**************************************\r\n")
-    println(Json.prettyPrint(json))
-    println("**************************************\r\n")
+    Logger.trace("\r\n**************************************\r\n")
+    Logger.trace(Json.prettyPrint(json))
+    Logger.trace("**************************************\r\n")
     json.validate[Notebook] match {
       case s: JsSuccess[Notebook] => {
         val notebook: Notebook = s.get

--- a/modules/subprocess/src/main/scala/notebook/kernel/pfork/BetterFork.scala
+++ b/modules/subprocess/src/main/scala/notebook/kernel/pfork/BetterFork.scala
@@ -128,7 +128,7 @@ class BetterFork[A <: ForkableProcess : reflect.ClassTag](config: Config,
       exec.setWorkingDirectory(workingDirectory)
       exec.execute(cmd, environment, new ExecuteResultHandler {
         Logger.info(s"Spawning $cmd")
-        Logger.info(s"With Env $environment")
+        Logger.trace(s"With Env $environment")
         Logger.info(s"In working directory $workingDirectory")
 
         def onProcessFailed(e: ExecuteException) {


### PR DESCRIPTION
I'd say these were polluting the logs rather much. If we ~trust this code, IMHO it can safely be disabled (furthermore it is quite unreadable).

Now logs for loading a notebook are 9 lines long, instead of thousands :)

To see these verbose messages again, set `logger.application=TRACE` in `conf/application.conf`.

@andypetrella 