### PR TITLE
Fix C3 styles in PivotChart

### DIFF
--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -76,3 +76,8 @@ table.pivot-controls-hidden, .pivot-controls-hidden > tbody > tr, .pivot-control
   /* align selected dimensions on the top, so easier to control them when there are many rows in table */
   vertical-align: top;
 }
+
+/* default styles from bokeh messes up c3-tooltip (pivotchart etc) */
+table.c3-tooltip {
+  background-color: #ffffff;
+}


### PR DESCRIPTION
fixes this ugly thing:  
<img width="177" alt="screen shot 2015-12-04 at 13 01 52" src="https://cloud.githubusercontent.com/assets/213426/11588181/3f5d8a48-9a87-11e5-9455-71539978ac7a.png">

cc @andypetrella 

we should review this later, to see if there isn't more CSS clashes.