### PR TITLE
Make PivotChart use full-width

### DIFF
--- a/app/assets/javascripts/notebook/magic/pivotChart.coffee
+++ b/app/assets/javascripts/notebook/magic/pivotChart.coffee
@@ -10,7 +10,6 @@ define([
   (dataO, container, options) ->
     require(['c3', 'pivotC3'],
     (c3, pivotC3) =>
-      w = options.width||600
       h = options.height||400
 
       derivers = $.pivotUtilities.derivers;
@@ -54,8 +53,8 @@ define([
       rendererOptions = {
                           c3: {
                             size: {
-                              height: h
-                              width: w
+                              height: h,
+                              width: $(container).width()
                             }
                           }
                         }

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -76,6 +76,11 @@ table.pivot-controls-hidden, .pivot-controls-hidden > tbody > tr, .pivot-control
   /* align selected dimensions on the top, so easier to control them when there are many rows in table */
   vertical-align: top;
 }
+/* auto-resize currently do not take account of the pivot controls.
+   to look less horrible, used white background */
+td.pvtRendererArea {
+  background-color: #ffffff;
+}
 
 /* default styles from bokeh messes up c3-tooltip (pivotchart etc) */
 table.c3-tooltip {


### PR DESCRIPTION
PivotChart is based on C3, which automatically handles resizing. 
Let's first enable full-width.

the good - looks awesome with extra space when controls are hidden:
<img width="1029" alt="screen shot 2015-12-08 at 18 45 11" src="https://cloud.githubusercontent.com/assets/213426/11661782/2ea7361a-9ddc-11e5-8af6-61e4760fc77e.png">


the bad - when controls are visible, it passed over the right margin. 
  * as first resort, added white background, so it looks better
  * it would be nice to resize the chart to a smaller one (looks like `pivottable` is not that flexible if it needs the render options, maybe it means a fix to `pivottable` is needed to do it properly).

<img width="1214" alt="screen shot 2015-12-09 at 12 40 02" src="https://cloud.githubusercontent.com/assets/213426/11683201/0f34e804-9e72-11e5-9cf5-cfd81651bd0c.png">


