### PR TITLE
Fix C3 tooltip title color (PivotChart)

### DIFF
--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -81,6 +81,9 @@ table.pivot-controls-hidden, .pivot-controls-hidden > tbody > tr, .pivot-control
 table.c3-tooltip {
   background-color: #ffffff;
 }
+table.c3-tooltip th {
+  color: #ffffff;
+}
 /* fix the black rect fill appearing in C3 Line charts (looks like a clash with something) */
 .pvtUi path.c3-shape.c3-line, .custom-c3-chart path.c3-shape.c3-line {
   fill: transparent;


### PR DESCRIPTION
from 
 <img width="63" alt="screen shot 2015-12-08 at 20 18 43" src="https://cloud.githubusercontent.com/assets/213426/11664185/f9d16674-9de8-11e5-940f-045f388af6ed.png">

 to 
<img width="67" alt="screen shot 2015-12-08 at 20 17 36" src="https://cloud.githubusercontent.com/assets/213426/11664190/00479cd0-9de9-11e5-8b2e-104deb40eedf.png">



cc @andypetrella 