### PR TITLE
Update View menu

### DIFF
--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -86,9 +86,7 @@
                         -->
 
                         <li class="divider"></li>
-                        <li id="report_view">
-                            <a href="?presentation=report" target="_blank">Report View (hide headers and code)</a>
-                        </li>
+
                         <!-- <li id="print_preview"><a href="#">Print Preview</a></li> -->
                         <li class="dropdown-submenu"><a href="#">Download as</a>
                             <ul class="dropdown-menu">
@@ -133,6 +131,15 @@
                 </li>
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>
                     <ul id="view_menu" class="dropdown-menu">
+                        <li id="report_view">
+                            <a href="?presentation=report" target="_blank">Report (results only)</a>
+                        </li>
+                        <li id="report_view_auto_refresh">
+                            <a href="?presentation=report&amp;recompute_now=true" target="_blank">
+                                Self-updating Report (results only; recompute on load)
+                            </a>
+                        </li>
+                        <li class="divider"></li>
                         <li id="toggle_header"
                             title="Show/Hide the IPython Notebook logo and notebook title (above menu bar)">
                             <a href="#">Toggle Header</a></li>

--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -139,6 +139,7 @@
                                 Self-updating Report (results only; recompute on load)
                             </a>
                         </li>
+                        <!--
                         <li class="divider"></li>
                         <li id="toggle_header"
                             title="Show/Hide the IPython Notebook logo and notebook title (above menu bar)">
@@ -146,6 +147,7 @@
                         <li id="toggle_toolbar"
                             title="Show/Hide the action icons (below menu bar)">
                             <a href="#">Toggle Toolbar</a></li>
+                         -->
                     </ul>
                 </li>
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Insert</a>


### PR DESCRIPTION
* Move Report-view menuitem to View menu	86f7194
* Hide useless toggle header/footer menu items

cc @andypetrella 

P.S. for `?presentation=report&recompute_now=true`  we should think what could happen if same notebook is open on multiple computers
  * couldn't autosave mess something up? and if so, how to solve it? turn off autosave for report view for now?