### PR TITLE
Make kernel autoStarting configurable

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -44,6 +44,7 @@ object Application extends Controller {
 
   val project = nbm.name
   val base_project_url = current.configuration.getString("application.context").getOrElse("/")
+  val autoStartKernel = current.configuration.getBoolean("manager.kernel.autostartOnNotebookOpen").getOrElse(true)
   val base_kernel_url = "/"
   val base_observable_url = "observable"
   val read_only = false.toString
@@ -569,6 +570,7 @@ object Application extends Controller {
                 "content" → j,
                 "name" → nbname,
                 "path" → fpath, //FIXME
+                "autoStartKernel" -> autoStartKernel,
                 "writable" -> true //TODO
               )
             } else {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,6 +80,10 @@ manager {
 
   kernel {
     ###
+    # Uncomment to not to start the kernel (spark-context) automatically when notebook was open
+    ## autostartOnNotebookOpen = false
+
+    ###
     # Uncomment to enable remote vm debugging on the provided port
     #
     #debug.port=9090

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -64,6 +64,10 @@ This will always be an empty file in IPython
   border: 1px solid #aaa;
 }
 
+.cell.failed {
+  background-color: #ee5f5b;
+}
+
 /* pivot chart */
 .pivot-controls-hidden .pvtVals, .pivot-controls-hidden .pvtRenderer, .pivot-controls-hidden .pvtAxisContainer {
   visibility: hidden;

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -385,6 +385,16 @@ define([
      * @method execute
      */
     CodeCell.prototype.execute = function (stop_on_error) {
+        if (!this.kernel) {
+            // will be handled by a notificationarea.js, showing a little msg to user
+            console.log("Can't execute, kernel is not initialized.");
+            this.events.trigger('kernel_not_started_yet.Kernel', this.notebook);
+            this.element.addClass("failed");
+            return;
+        } else {
+            this.element.removeClass("failed");
+        }
+
         if (!this.kernel || !this.kernel.is_connected()) {
             console.log("Can't execute, kernel is not connected.");
             return;

--- a/public/ipython/notebook/js/notificationarea.js
+++ b/public/ipython/notebook/js/notificationarea.js
@@ -77,6 +77,12 @@ define([
             }, {title: 'click to reconnect'});
         });
 
+        this.events.on('kernel_not_started_yet.Kernel', function (evt, notebook) {
+            knw.danger("No Kernel. Click to start", undefined, function () {
+                notebook.start_session();
+            }, {title: 'click to start'});
+        });
+
         this.events.on('kernel_connected.Kernel', function () {
             knw.info("Connected", 500);
         });


### PR DESCRIPTION
Allows to save resources when people open a notebook for viewing only:

- [x] add `autostartOnNotebookOpen = false | true`
  * when `= false`, no kernel is started - one needs to click `Restart kernel` before being able to execute any cell commands
- [x] add some clear message in red letters informing user ?

<img width="1188" alt="screen shot 2015-12-12 at 16 42 49" src="https://cloud.githubusercontent.com/assets/213426/11762454/73ce535c-a0ef-11e5-82b4-dae8efdac05b.png">
