### PR TITLE
Added conf `manager.notebooks.override`

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,12 +50,27 @@ manager {
     dir = ./notebooks
 
     ###
-    # Default custom configuration for all notebooks
+    # Default custom configuration for all **CREATED** notebooks
     #
     # custom {
     #   localRepo  = "/tmp/repo",
     #   repos      = ["m" %  "default" % "http://repo.maven.apache.org/maven2/" % "maven"],
-    #   deps       = ["junit % junit % 1.14"],
+    #   deps       = ["junit % junit % 4.12"],
+    #   imports    = ["import scala.util._"],
+    #   sparkConf  = {
+    #     spark.number.works.too : "test",
+    #     spark.boh: 2
+    #   }
+    # }
+
+    ###
+    # Override custom configuration for **ALL** notebooks
+    #  TO USE WITH CARE → could break full reproductability
+    #
+    # override {
+    #   localRepo  = "/tmp/repo",
+    #   repos      = ["m" %  "default" % "http://repo.maven.apache.org/maven2/" % "maven"],
+    #   deps       = ["junit % junit % 4.12"],
     #   imports    = ["import scala.util._"],
     #   sparkConf  = {
     #     spark.number.works.too : "test",


### PR DESCRIPTION
This new configuration takes the same form as `manager.notebooks.custom`.
The `custom` one will be only applied for new notebooks, however this new one will
be applied on any notebooks that are launched by the server. So to use with care.

This is for instance helpful for spark-notebook instance running on one single cluster
that would require specific libraries in the path. Or in order to bind to specific IP.

cc @vidma  @mvherweg @radekg