### PR TITLE
Fix/repl class server not closed

### DIFF
--- a/modules/spark/src/main/scala_2.10/spark-1.2.0/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.2.0/notebook/kernel/Repl.scala
@@ -253,6 +253,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.2.1/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.2.1/notebook/kernel/Repl.scala
@@ -253,6 +253,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.2.2/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.2.2/notebook/kernel/Repl.scala
@@ -253,6 +253,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.2.3/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.2.3/notebook/kernel/Repl.scala
@@ -253,6 +253,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.3.0/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.3.0/notebook/kernel/Repl.scala
@@ -260,6 +260,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
     val prevCode = requests.map(_.originalLine)
     val jarList = newJars:::jars
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, jarList)
     (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.3.1/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.3.1/notebook/kernel/Repl.scala
@@ -262,6 +262,8 @@ class Repl(val compilerOpts: List[String], val jars: List[String] = Nil) {
 
     val prevCode = requests.map(_.originalLine)
     val jarList = newJars ::: jars
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, jarList)
     (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.3.2/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.3.2/notebook/kernel/Repl.scala
@@ -260,6 +260,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
     val prevCode = requests.map(_.originalLine)
     val jarList = newJars:::jars
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, jarList)
     (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.4.0/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.4.0/notebook/kernel/Repl.scala
@@ -260,6 +260,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
     val prevCode = requests.map(_.originalLine)
     val jarList = newJars:::jars
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, jarList)
     (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.4.1/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.4.1/notebook/kernel/Repl.scala
@@ -260,6 +260,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
     val prevCode = requests.map(_.originalLine)
     val jarList = newJars:::jars
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, jarList)
     (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.5.0/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.5.0/notebook/kernel/Repl.scala
@@ -260,6 +260,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
     val prevCode = requests.map(_.originalLine)
     val jarList = newJars:::jars
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, jarList)
     (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-1.5.1/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-1.5.1/notebook/kernel/Repl.scala
@@ -260,6 +260,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
     val prevCode = requests.map(_.originalLine)
     val jarList = newJars:::jars
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, jarList)
     (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.10/spark-last/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-last/notebook/kernel/Repl.scala
@@ -260,6 +260,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
     val prevCode = requests.map(_.originalLine)
     val jarList = newJars:::jars
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, jarList)
     (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.2.0/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.2.0/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.2.1/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.2.1/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.2.2/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.2.2/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.2.3/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.2.3/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.3.0/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.3.0/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.3.1/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.3.1/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.3.2/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.3.2/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.4.0/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.4.0/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.4.1/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.4.1/notebook/kernel/Repl.scala
@@ -252,6 +252,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.5.0/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.5.0/notebook/kernel/Repl.scala
@@ -255,6 +255,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-1.5.1/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-1.5.1/notebook/kernel/Repl.scala
@@ -255,6 +255,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }

--- a/modules/spark/src/main/scala_2.11/spark-last/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-last/notebook/kernel/Repl.scala
@@ -255,6 +255,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
 
   def addCp(newJars:List[String]) = {
     val prevCode = interp.prevRequestList.map(_.originalLine)
+    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    interp.close()
     val r = new Repl(compilerOpts, newJars:::jars)
     (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
   }


### PR DESCRIPTION
This makes the usage of `spark.replClassServer.port` trick inefficient because the new http server
won't be able to start on the requested port.

> **HOWEVER** this won't work with scala 2.11 !!!! Because the `spark.replClassServer.port` is simply
> not **USED**, see [here until 1.5.2](https://github.com/apache/spark/blob/v1.5.2/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala#L39).
> But also, see [here from 1.6.0](https://github.com/apache/spark/blob/master/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala#L88) which uses `spark.repl.class.outputDir` instead. This property will be used by the `SparkContext` to update its `RpcEnv` →  not yet supported by the Spark Notebook, hence will need more testing when this version will be released!

@radekg could you give this PR a try?
Also please, note the comment on the scala version and spark version!!! Really important (and odd...)