### PR TITLE
PivotChart: Rotate and limit x labels count, fix padding

### DIFF
--- a/app/assets/javascripts/notebook/magic/pivotChart.coffee
+++ b/app/assets/javascripts/notebook/magic/pivotChart.coffee
@@ -51,13 +51,26 @@ define([
         save_pivot_state(extract_pivot_state(options))
 
       rendererOptions = {
-                          c3: {
-                            size: {
-                              height: h,
-                              width: $(container).width()
-                            }
-                          }
-                        }
+        c3: {
+          size: {
+            height: h,
+            width: $(container).width()
+          },
+          padding: {
+            # make sure x labels fit
+            right: 50
+          },
+          axis: {
+            x: {
+              tick: {
+                culling: { max: 25 },
+                rotate: 75,
+                multiline: false
+              }
+            }
+          }
+        }
+      }
       window.c3 = c3
 
       pivotOptions = get_saved_pivot_state()


### PR DESCRIPTION
gives this (almost)-awesomeness:


<img width="683" alt="screen shot 2015-12-15 at 22 10 47" src="https://cloud.githubusercontent.com/assets/213426/11822753/df27828c-a378-11e5-8a2f-bcc2162e1a5d.png">

addresses #432 