### PR TITLE
Align unused columns on the top

### DIFF
--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -76,8 +76,9 @@ This will always be an empty file in IPython
 table.pivot-controls-hidden, .pivot-controls-hidden > tbody > tr, .pivot-controls-hidden > tbody > tr > td {
   border: none ! important;
 }
-.pvtUi td.pvtAxisContainer.pvtRows {
-  /* align selected dimensions on the top, so easier to control them when there are many rows in table */
+.pvtUi td.pvtAxisContainer.pvtRows, td.pvtAxisContainer.pvtUnused.pvtVertList {
+  /* align both selected and unselected dimensions on the top,
+  so it's easier to control them when there are many rows or many columns in a table */
   vertical-align: top;
 }
 /* auto-resize currently do not take account of the pivot controls.


### PR DESCRIPTION
Align unused columns on the top so it's at least possible to reach them.

<img width="737" alt="screen shot 2015-12-16 at 11 44 27" src="https://cloud.githubusercontent.com/assets/213426/11837589/86bc501a-a3ea-11e5-9aff-8241b838f452.png">

P.S. it's rather weird that `pivottable` changes arranged when there's many columns..

cc @andypetrella 