### PR TITLE
Intelligent auto-completions

### DIFF
--- a/app/notebook/server/CalcWebSocketService.scala
+++ b/app/notebook/server/CalcWebSocketService.scala
@@ -227,7 +227,7 @@ class CalcWebSocketService(
           case CompletionResponse(cursorPosition, candidates, matchedText) =>
             ws.send(header, session, "complete_reply", "shell", obj(
               "matched_text" → matchedText,
-              "matches" → candidates.map(_.toJson).toList,
+              "matches" → candidates.map(_.toJsonWithDescription).toList,
               "cursor_start" → (cursorPosition - matchedText.length),
               "cursor_end" → cursorPosition))
             context.stop(self)

--- a/modules/common/src/main/scala/notebook/util/StringCompletor.scala
+++ b/modules/common/src/main/scala/notebook/util/StringCompletor.scala
@@ -8,6 +8,14 @@ import play.api.libs.json._
 
 case class Match(matchedValue: String, metadata: Map[String, String]) {
   def toJson = JsString(matchedValue)
+
+  def toJsonWithDescription = {
+    JsObject(
+      Seq(
+        ("value", JsString(matchedValue)),
+        ("display_text", JsString(metadata.getOrElse("display_text", matchedValue)))
+      ))
+  }
 }
 
 object Match {

--- a/modules/kernel/src/main/scala/notebook/PresentationCompiler.scala
+++ b/modules/kernel/src/main/scala/notebook/PresentationCompiler.scala
@@ -59,13 +59,15 @@ class PresentationCompiler(dependencies: List[String]) {
       result = compiler.ask( () => {
         response.get(10) match {
           case Some(Left(t)) =>
-            t .map( m => CompletionInformation(
-                  m.sym.nameString,
-                  m.tpe.params.map( p => s"${p.name.toString}: ${p.tpe.toString()}").mkString(", "),
-                  m.tpe.resultType.toString
-                )
-              )
-              .toSeq
+            t .map { m =>
+              val params = m.tpe.params.map(p => s"${p.name.toString}: ${p.tpe.toString()}").mkString(", ")
+              val returnType = try {
+                m.tpe.resultType.toString
+              } catch {
+                case exc: RuntimeException => println("Unable to get symbol type", exc); "?"
+              }
+              CompletionInformation(m.sym.nameString, params, returnType)
+            }.toSeq
           case Some(Right(ex)) =>
             ex.printStackTrace()
             println(ex)

--- a/modules/kernel/src/main/scala/notebook/PresentationCompiler.scala
+++ b/modules/kernel/src/main/scala/notebook/PresentationCompiler.scala
@@ -98,26 +98,11 @@ class PresentationCompiler(dependencies: List[String]) {
     if(matches.isEmpty) {
       matches = completion (pos, compiler.askScopeCompletion)
     }
-    val returnMatches: Seq[Match] = matches
+    val returnMatches = matches
       .filter(m => m.symbol.startsWith(filterSnippet))
-      .map {
-        // if text already matches the method-name, autocomplete all matching method versions (name, params, returnType)
-        case m if m.symbol == filterSnippet =>
-          val metadata = Map("display_text" -> m.nameParamsAndReturnType, "dedup_key" -> m.nameParamsAndReturnType)
-          Match(m.nameAndParams, metadata)
-        // otherwise, autocomplete only method name, but we'll display the first matching signature
-        case m =>
-          Match(m.symbol, Map("display_text" -> m.nameParamsAndReturnType, "dedup_key" -> m.symbol))
-      }
-      .groupBy(_.metadata("dedup_key"))
-      .map {
-        case (_, matches) if matches.size > 1 =>
-          val m = matches.head
-          val updatedDisplayText = s"${m.metadata("display_text")} [multiple versions]"
-          Match(m.matchedValue, m.metadata.updated("display_text", updatedDisplayText))
-        case (_, matches) => matches.head
-      }.toSeq
-
-    (filterSnippet, returnMatches)
+      // autocomplete all matching method versions (name, params, returnType)
+      .map { m => Match(m.nameAndParams, Map("display_text" -> m.nameParamsAndReturnType))}
+      .distinct
+    (filterSnippet,returnMatches)
   }
 }

--- a/public/ipython/notebook/js/completer.js
+++ b/public/ipython/notebook/js/completer.js
@@ -23,7 +23,8 @@ define([
 
     var _existing_completion = function(item, completion_array){
         for( var i=0; i < completion_array.length; i++) {
-            if (completion_array[i].trim().substr(-item.length) == item) {
+            var completion_text = completion_array[i].value.trim();
+            if (completion_text.substr(-item.length) == item) {
                 return true;
             }
         }
@@ -221,7 +222,8 @@ define([
         // positon and matched_text length.
         for (i = matches.length - 1; i >= 0; --i) {
             filtered_results.unshift({
-                str: matches[i],
+                str: matches[i].value,
+                display_text: matches[i].display_text,
                 type: "introspection",
                 from: utils.from_absolute_cursor_pos(this.editor, start),
                 to: utils.from_absolute_cursor_pos(this.editor, end)
@@ -315,7 +317,13 @@ define([
 
     Completer.prototype.build_gui_list = function (completions) {
         for (var i = 0; i < completions.length; ++i) {
-            var opt = $('<option/>').text(completions[i].str).addClass(completions[i].type);
+            // show more verbose text if exists
+            // the completion value will be selected from completions.str, in this.pick()
+            var display_text = completions[i].display_text;
+            if (display_text === undefined) {
+                display_text = completions[i].str;
+            }
+            var opt = $('<option/>').text(display_text).addClass(completions[i].type);
             this.sel.append(opt);
         }
         this.sel.children().first().attr('selected', 'true');

--- a/test/notebook/PresentationCompilerTests.scala
+++ b/test/notebook/PresentationCompilerTests.scala
@@ -34,12 +34,26 @@ class PresentationCompilerTests extends Specification {
 
       val c = complete(pc) _
       c(code, code.size) must beEqualTo("toS", Set(
-        Match("toString", Map.empty[String,String]),
-        Match("toSchwarz", Map.empty[String,String])
+        Match("toSchwarz", Map("display_text" -> "toSchwarz: Float")),
+        Match("toString", Map("display_text" -> "toString: String"))
       ))
-      c(code+"\nval testAsSt$ring = test.toString()", code.size) must beEqualTo("toS", Set(
-        Match("toString", Map.empty[String,String]),
-        Match("toSchwarz", Map.empty[String,String])
+      c(code + "\nval testAsSt$ring = test.toString()", code.size) must beEqualTo("toS", Set(
+        Match("toSchwarz", Map("display_text" -> "toSchwarz: Float")),
+        Match("toString", Map("display_text" -> "toString: String"))
+      ))
+    }
+
+    "lists all overrided method versions" in {
+      val line = "test.testMeth"
+      val code = List(newInst, newLine, line).mkString
+
+      val pc = new PresentationCompiler(Nil)
+      pc.addScripts(cz)
+      val c = complete(pc) _
+
+      c(code, code.size) must beEqualTo("testMeth", Set(
+        Match("testMethod(a: String)", Map("display_text" -> "testMethod(a: String): String")),
+        Match("testMethod(a: String, b: String)", Map("display_text" -> "testMethod(a: String, b: String): String"))
       ))
     }
 
@@ -50,7 +64,7 @@ class PresentationCompilerTests extends Specification {
       val c = complete(pc) _
 
       val code1 = List(newInst, newLine, "test.").mkString
-      c(code1, code1.size)._2.size must beEqualTo(32)
+      c(code1, code1.size)._2.size must beEqualTo(43)
 
       val code2 = List(newLine, newInst, newLine, "test.testMethod(").mkString
       c(code2, code2.size-1)._2.size must beEqualTo(2)


### PR DESCRIPTION
this completer need a bit more love and refactoring but lets start simple.

- [x] basis for complex completions where text and completion value could differ, so `Match. toJsonWithDescription` gives a dict with:
  * `value` (the replacement to be put in code)
  * `display_text` - complete method signature, e.g. `method_name(params...): return_type` shown only in dropdown
- [x] format method signatures more naturally: 
  *  `method_name(param1: paramType, param2: paramType)`
- [x] always show all matching versions of a method/member including its return type:
  * i.e. `method_name(params...): return_type`
- [x] update tests

this gives much more advanced auto-comletions than in databricks-notebooks, hurray :tada: :balloon: 

in future we could show the docstrings if they exist. this would need some fancy tooltip box.

---

* data member completions, show ALL versions of a method with a full signature:
  - also, this do not add `()` anymore when parameters are empty, as it matches are not `methods` necessarily 

<img width="701" alt="screen shot 2015-12-17 at 12 34 47" src="https://cloud.githubusercontent.com/assets/213426/11867578/ac19e5fe-a4ba-11e5-9567-913cf3ab17d3.png">


* selecting a match:
<img width="687" alt="screen shot 2015-12-16 at 18 28 38" src="https://cloud.githubusercontent.com/assets/213426/11847044/29f4e68c-a424-11e5-9eb5-18226606e847.png">

fixes #445 