### PR TITLE
Refactor sampling and use limit in DataFrames

### DIFF
--- a/modules/common/src/main/scala/notebook/front/widgets/Magic.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/Magic.scala
@@ -73,9 +73,14 @@ case class Edge[I](id:I, ends:(I, I), value:Any, color:String="#999") extends Gr
                                   StringPoint(color, headers=Seq("color"))
 }
 
+sealed trait SamplingStrategy
+case class LimitBasedSampling extends SamplingStrategy
+case class RandomSampling extends SamplingStrategy
+
 object SamplerImplicits extends ExtraSamplerImplicits {
   trait Sampler[C] {
     def apply(c:C, max:Int):C
+    def samplingStrategy: SamplingStrategy = RandomSampling()
   }
 
   implicit def SeqSampler[T] = new Sampler[Seq[T]] {

--- a/modules/common/src/main/scala/notebook/front/widgets/package.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/package.scala
@@ -7,6 +7,7 @@ import com.vividsolutions.jts.geom.Geometry
 import org.wololo.geojson.GeoJSON
 import notebook._
 import notebook.JsonCodec._
+import notebook.front.widgets.magic
 import notebook.front.widgets.magic._
 import notebook.front.widgets.magic.Implicits._
 import notebook.front.widgets.magic.SamplerImplicits._
@@ -323,6 +324,8 @@ package object widgets {
     def originalData:C
     def maxPoints:Int
 
+    def sampler = implicitly[Sampler[C]]
+
     def toPoints = implicitly[ToPoints[C]]
     lazy val points:Seq[MagicRenderPoint] = toPoints(originalData, maxPoints)
 
@@ -344,7 +347,10 @@ package object widgets {
       if (currentMax >= toPoints.count(currentC)) {
         ""
       } else {
-        " (Warning: randomly sampled "+currentMax + " entries)"
+        sampler.samplingStrategy match {
+          case magic.LimitBasedSampling() => " (Warning: showing first "+currentMax + " rows)"
+          case _ => " (Warning: randomly sampled "+currentMax + " entries)"
+        }
       }
     }
 

--- a/modules/common/src/main/scala/notebook/front/widgets/package.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/package.scala
@@ -340,13 +340,17 @@ package object widgets {
     @volatile var currentPoints = points
     @volatile var currentMax = maxPoints
 
+    def samplingWarning(maxEntriesLimit: Int): String = {
+      if (currentMax >= toPoints.count(currentC)) {
+        ""
+      } else {
+        " (Warning: randomly sampled "+currentMax + " entries)"
+      }
+    }
+
     maxPointsBox.currentData --> Connection.fromObserver { max:Int =>
       currentMax = max
-      if (currentMax >= toPoints.count(currentC)) {
-        warnMax("")
-      } else{
-        warnMax(" (Warning: randomly sampled "+currentMax + " entries)")
-      }
+      warnMax(samplingWarning(currentMax))
       applyOn(currentC)
     }
 
@@ -355,11 +359,7 @@ package object widgets {
       maxPointsBox.currentData <-- Connection.just(max)
       //update state
       currentMax = max
-      if (currentMax >= toPoints.count(currentC)) {
-        warnMax("")
-      } else{
-        warnMax(" (Warning: randomly sampled "+currentMax + " entries)")
-      }
+      warnMax(samplingWarning(currentMax))
       applyOn(currentC)
     }
 


### PR DESCRIPTION
- [x] Refactor warning that sampling was applied
- [x] Use the faster `df.limit(max)` instead of `df.sample()`
  * the best would be to avoid a call to df.count() altogether, but isn't so simple, this will be addressed later...
- [x] Remove unnecessary `.count()/.take()` stages, so DataFrames are used more efficiently
- [x] Increase maxPoints default to `1000` #459

@andypetrella 