### PR TITLE
Add notebook path to spark appName

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -182,7 +182,7 @@ object Application extends Controller {
       KernelManager.add(kId, kernel)
 
       val service = new CalcWebSocketService(kernelSystem,
-        md.map(_.name).getOrElse("Spark Notebook"),
+        appNameToDisplay(md, notebookPath),
         customLocalRepo,
         customRepos,
         customDeps,
@@ -591,6 +591,17 @@ object Application extends Controller {
       ref ! akka.actor.PoisonPill
     }
   )
+
+  /**
+    * The notebook name to attach to Spark Context (and all related jobs)
+    */
+  def appNameToDisplay(metadata: Option[Metadata], notebookPath: Option[String]): String = {
+    val explicitName = metadata.map(_.name).getOrElse("Spark-notebook")
+    notebookPath match {
+      case Some(path) => s"${explicitName} ($path)"
+      case None => explicitName
+    }
+  }
 
   def getNotebook(name: String, path: String, format: String, dl: Boolean = false) = {
     try {


### PR DESCRIPTION
Make it easier to identify which spark applications belong to which notebooks (when people copy notebook the appName in metadata stay the same, or if notebooks are in different dirs)

will look like this: `Old Explicit Name (sql/DataFrame.snb)`

fixed #427 

cc @andypetrella 