### PR TITLE
Generated appName to override spark.app.name in nb metadata

### DIFF
--- a/conf/scripts/init.sc
+++ b/conf/scripts/init.sc
@@ -42,8 +42,8 @@ import org.apache.spark.rdd._
   def reset(appName:String=notebookName, lastChanges:(SparkConf=>Unit)=(_:SparkConf)=>()):Unit = {
     conf = new SparkConf()
     conf.setMaster(sparkMaster.getOrElse("local[*]"))
-        .setAppName(appName)
         .setAll(_5C4L4_N0T3800K_5P4RK_C0NF.toList)
+        .setAppName(appName)
         .set("spark.repl.class.uri", uri)
 
     execMemory foreach (v => conf.set("spark.executor.memory", v))


### PR DESCRIPTION
if notebook metadata contained this, it would override the generated spark app-name.
```json
  "customSparkConf": {
    "spark.app.name": "overrides the generated"
  }
```

when there is many notebooks it is too hard to track each nb metadata. so make generated app-name to override the earlier.

fixes #461 