### PR TITLE
Display widget for more than 2 fields

### DIFF
--- a/modules/common/src/main/scala/notebook/front/widgets/package.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/package.scala
@@ -645,7 +645,7 @@ package object widgets {
 
     val tbl = Some("table" → TableChart(originalData, maxPoints=maxPoints))
 
-    if(numOfFields == 2 || fields.isDefined){
+    val twoFieldCharts = if(numOfFields == 2 || fields.isDefined){
       val (f1, f2)  = fields.map{ case (f1, f2) => (dataMap(f1), dataMap(f2)) }
                             .getOrElse((members(0), members(1)))
 
@@ -653,18 +653,14 @@ package object widgets {
       val line:Option[(String, Chart[C])]    = if (isNumber(f1) && isNumber(f2)) { Some("line-chart" → LineChart(originalData, fields,maxPoints=maxPoints)) } else None
       val bar :Option[(String, Chart[C])]    = if (isNumber(f2)) { Some("bar-chart" → BarChart(originalData, fields,maxPoints=maxPoints)) } else None
       val pie :Option[(String, Chart[C])]    = if (!isNumber(f1)) { Some("pie-chart" → PieChart(originalData, fields,maxPoints=maxPoints)) } else None
-      val pivot:Option[(String, Chart[C])]   = Some("cubes" → PivotChart(originalData, maxPoints=maxPoints))
-      val allTabs:Seq[Option[(String, Chart[C])]] = tbl :: scatter :: line :: bar :: pie :: pivot :: Nil
-      tabs(originalData, allTabs.collect{ case Some(t) => t})
-    } else {
-      val main =
-        widgets.containerFluid(List(
-          List(
-            tbl.get._2 → 12
-          )
-        ))
-      main
-    }
+
+      scatter :: line :: bar :: pie :: Nil
+    } else Nil
+
+    val pivot = Some("cubes" → PivotChart(originalData, maxPoints=maxPoints))
+
+    val allTabs = (tbl :: twoFieldCharts ::: pivot :: Nil).collect { case Some(t) => t }
+    tabs(originalData, allTabs)
   }
 
   def isNumber(obj: Any) = obj.isInstanceOf[Int] || obj.isInstanceOf[Float] || obj.isInstanceOf[Double] || obj.isInstanceOf[Long]


### PR DESCRIPTION
table & pivot charts are always displayable, so always show the tabs.

<img width="550" alt="screen shot 2015-12-18 at 23 26 22" src="https://cloud.githubusercontent.com/assets/213426/11907699/ccc7c314-a5de-11e5-87cd-9e32ff39dc26.png">


cc @andypetrella 