### PR TITLE
Initialize observables when kernel is ready

### DIFF
--- a/public/javascripts/notebook/observable.js
+++ b/public/javascripts/notebook/observable.js
@@ -266,7 +266,7 @@ return new function () {
   } else {
     console.warn("Observable init delayed because kernel id not available (IPython.notebook.kernel.id)")
     console.debug("Observable delayed, IPython object is: ", IPython)
-    events.on('app_initialized.NotebookApp', function(o) {
+    events.on('kernel_ready.Kernel', function(o) {
       if (!me.isInitialized()) {
         console.warn("Delayed observable is now starting");
         me.start(); //avoid pre-init of IPython → .kernel.id is null


### PR DESCRIPTION
- notice app_initialized.NotebookApp is triggered [way before kernel load](https://github.com/andypetrella/spark-notebook/blob/master/public/ipython/notebook/js/main.js#L158-L161):
  * and even before loading of notebook, which in turn on success calls load_notebook_success, which only initiates kernel start (kernel.start_session()).
- and observable.start(), as I understand, relays on a kernel to be initialized.

a quickfix is to simply change this initialization to happen on kernel_ready.Kernel. This should, hopefully, fix the mysterious cases when progressbar is non-visible!