### PR TITLE
Improve sumOverSum label

### DIFF
--- a/app/assets/javascripts/notebook/magic/pivotChart.coffee
+++ b/app/assets/javascripts/notebook/magic/pivotChart.coffee
@@ -86,11 +86,14 @@ define([
       pivotOptions.onRefresh = refresh
       pivotOptions.rendererOptions = rendererOptions
 
-      customAggregators = {
+      # rename "sumOverSum" into a more readable name "Ratio"
+      customAggregators = $.extend($.pivotUtilities.aggregators, {
         # allows calculating ratios over any dimensions (sum is additive, ratio is not)
-        "Ratio - sumOverSum": $.pivotUtilities.aggregatorTemplates.sumOverSum()
-      }
-      pivotOptions.aggregators = $.extend($.pivotUtilities.aggregators, customAggregators)
+        "Ratio": $.pivotUtilities.aggregatorTemplates.sumOverSum()
+      })
+      delete customAggregators["Sum over Sum"]
+
+      pivotOptions.aggregators = customAggregators
 
       p = $("<div>")
       p.addClass("pivotChart").appendTo(container)


### PR DESCRIPTION
- the newer `pivottable` already included `sumOverSum` aggregator by default, so `Ratio - sumOverSum` was quite redundant
- rename the `Ratio - sumOverSum` into simply `Ratio`, so chart labels are more human-readable:
  * e.g. from `Ratio - sumOverSum(visits, sales) by city` to `Ratio(visits, sales) by city`

cc @andypetrella 
fixes #472