### PR TITLE
Enabling -Yrepl-class-based on scala_2.11 and latest spark.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ notebooks/parleys-notebooks
 notebooks/virdata
 notebooks/oreilly
 notebooks/cassandra/Cassandra and G3nerator.snb
+/bin/
+.cache-main
+.cache-tests

--- a/modules/spark/src/main/scala_2.11/spark-last/Boot.scala
+++ b/modules/spark/src/main/scala_2.11/spark-last/Boot.scala
@@ -2,20 +2,18 @@ package org.apache.spark
 
 import org.apache.spark.util.Utils
 import org.apache.spark._
-
 import scala.tools.nsc.Settings
+import java.io.File
 
 object Boot {
-  def classServer = {
+  def classServer(outputDir:File) = {
     val conf = new SparkConf()
-
-    val tmp = System.getProperty("java.io.tmpdir")
-    val rootDir = conf.get("spark.repl.classdir", tmp)
-    val outputDir = Utils.createTempDir(rootDir)
-    val s = new Settings()
-    s.processArguments(List("-Yrepl-class-based", "-Yrepl-outdir", s"${outputDir.getAbsolutePath}", "-Yrepl-sync"), true)
     val server = new HttpServer(conf, outputDir, new SecurityManager(conf))
     server
   }
+  
+  def createTempDir(
+      root: String = System.getProperty("java.io.tmpdir"),
+      namePrefix: String = "spark"): File = Utils.createTempDir(root, namePrefix)
 
 }

--- a/modules/spark/src/main/scala_2.11/spark-last/HackSparkILoop.scala
+++ b/modules/spark/src/main/scala_2.11/spark-last/HackSparkILoop.scala
@@ -8,14 +8,17 @@ import scala.tools.nsc.util.ScalaClassLoader._
 import scala.reflect.api.{Mirror, TypeCreator, Universe => ApiUniverse}
 import scala.concurrent.{ ExecutionContext, Await, Future, future }
 import ExecutionContext.Implicits._
+import java.io.File
 
 
 import scala.tools.nsc.interpreter._
 
-class HackSparkILoop(out:JPrintWriter) extends org.apache.spark.repl.SparkILoop(None, out) {
+class HackSparkILoop(out:JPrintWriter, outputDir:File) extends org.apache.spark.repl.SparkILoop(None, out) {
 
+  // note:
+  // the creation of SecurityManager has to be lazy so SPARK_YARN_MODE is set if needed
   val classServer = {
-    val s = org.apache.spark.Boot.classServer
+    val s = org.apache.spark.Boot.classServer(outputDir)
     s.start
     s
   }


### PR DESCRIPTION
I don't know why, but it looks this option doesn't work in Boot class. Also I was concerned about the correct folder for the `spark.repl.classdir` and classServer, so I pass this option explicitly.

I have tested this in local and standalone mode, albeit on the same machine.  Fixes #481