### PR TITLE
Simplify appName

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -596,9 +596,9 @@ object Application extends Controller {
     * The notebook name to attach to Spark Context (and all related jobs)
     */
   def appNameToDisplay(metadata: Option[Metadata], notebookPath: Option[String]): String = {
-    val explicitName = metadata.map(_.name).getOrElse("Spark-notebook")
+    val explicitName = metadata.map(_.name).getOrElse("Spark notebook")
     notebookPath match {
-      case Some(path) => s"${explicitName} ($path)"
+      case Some(path) => path
       case None => explicitName
     }
   }


### PR DESCRIPTION
notebookPath is [always the same as metadata.name](https://github.com/andypetrella/spark-notebook/blob/d3f8413205a43f9df8af4dbfb6a7e1c92c3ce939/app/notebook/server/NotebookManager.scala#L113), so remove the duplication.

improves #461

cc @andypetrella 