### PR TITLE
Make Y axis min-value configurable

### DIFF
--- a/app/assets/javascripts/notebook/magic/pivotChart.coffee
+++ b/app/assets/javascripts/notebook/magic/pivotChart.coffee
@@ -78,6 +78,12 @@ define([
       }
       window.c3 = c3
 
+      if options.extraOptions.y_start_at?
+        rendererOptions.c3.axis.y = {
+          min: Number(options.extraOptions.y_start_at),
+          padding: { bottom: 0 }
+        }
+
       pivotOptions = get_saved_pivot_state()
       # console.log("saved_pivot_state=", pivotOptions)
 

--- a/modules/common/src/main/scala/notebook/front/widgets/package.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/package.scala
@@ -416,11 +416,18 @@ package object widgets {
     originalData:C,
     override val sizes:(Int, Int)=(600, 400),
     maxPoints:Int = DEFAULT_MAX_POINTS,
-    derivedAttributes:JsObject=play.api.libs.json.Json.obj()
+    derivedAttributes:JsObject=play.api.libs.json.Json.obj(),
+    options: Map[String, String] = Map.empty
   ) extends Chart[C] {
     def mToSeq(t:MagicRenderPoint):Seq[(String, Any)] = t.data.toSeq
 
-    override val scripts = List(Script( "magic/pivotChart", Json.obj("width" → sizes._1, "height" → sizes._2, "derivedAttributes" → derivedAttributes)))
+    protected def optionsJson = Json.obj(options.mapValues(Json.toJsFieldJsValueWrapper(_)).toSeq: _*)
+
+    override val scripts = List(Script( "magic/pivotChart", Json.obj("width" → sizes._1,
+                                                                     "height" → sizes._2,
+                                                                     "derivedAttributes" → derivedAttributes,
+                                                                     "extraOptions" → optionsJson)
+    ))
   }
 
   case class ScatterChart[C:ToPoints:Sampler](originalData:C, fields:Option[(String, String)]=None, override val sizes:(Int, Int)=(600, 400), maxPoints:Int = DEFAULT_MAX_POINTS) extends Chart[C] {


### PR DESCRIPTION
when needed, this allows to see the global picture (when very small changes in values are not important). earlier these tiny changes would look like big ones.

without:
<img width="668" alt="screen shot 2015-12-31 at 17 08 48" src="https://cloud.githubusercontent.com/assets/213426/12065543/c3b205f2-afe1-11e5-8284-73b109fd7e4f.png">

with:
<img width="691" alt="screen shot 2015-12-31 at 17 09 20" src="https://cloud.githubusercontent.com/assets/213426/12065538/be65c4e4-afe1-11e5-9c98-d2702f5b4186.png">
