### PR TITLE
Fix job canceling

### DIFF
--- a/app/notebook/server/CalcWebSocketService.scala
+++ b/app/notebook/server/CalcWebSocketService.scala
@@ -167,9 +167,9 @@ class CalcWebSocketService(
           )
           self ! PoisonPill
         } else {
-          if (currentSessionOperations.nonEmpty) {
-            currentSessionOperations = currentSessionOperations.dequeue._2
-          }
+          // any cell can be interrupted, so remove the relevant operation only
+          Logger.debug(s"Termination of op calculator: ${currentSessionOperations.filter(_.actor == actor)}")
+          currentSessionOperations = currentSessionOperations.filter(_.actor != actor)
         }
 
       case event:org.apache.log4j.spi.LoggingEvent =>

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -229,7 +229,7 @@ class ReplCalculator(
         log.debug(s"Interrupting the cell: $killCellId")
         val jobGroupId = JobTracking.jobGroupId(killCellId)
         // make sure sparkContext is already available!
-        if (jobsInQueueToKill.isEmpty && repl.interp.allImportedNames.exists(_.toString == "sparkContext")) {
+        if (jobsInQueueToKill.isEmpty && repl.interp.allDefinedNames.exists(_.toString == "globalScope")) {
           log.info(s"Killing job Group $jobGroupId")
           val thisSender = sender()
           repl.evaluate(
@@ -414,7 +414,7 @@ class ReplCalculator(
             )
           }
           finally {
-             repl.evaluate("sparkContext.clearJobGroup()")
+             repl.evaluate("globalScope.sparkContext.clearJobGroup()")
           }
           cellResult
         }

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -226,15 +226,15 @@ class ReplCalculator(
         log.debug(s"Canceling $killCellId jobs still in queue (if any):\n $jobsInQueueToKill")
         queue = nonAffectedJobs
 
-        // call cancelJobGroup even if job was in queue
-        // this is safe in recent spark versions, see SPARK-6414
         log.debug(s"Interrupting the cell: $killCellId")
         val jobGroupId = JobTracking.jobGroupId(killCellId)
         // make sure sparkContext is already available!
-        if (repl.interp.allDefinedNames.filter(_.toString == "sparkContext").nonEmpty) {
+        if (jobsInQueueToKill.isEmpty && repl.interp.allImportedNames.exists(_.toString == "sparkContext")) {
+          log.info(s"Killing job Group $jobGroupId")
+          val thisSender = sender()
           repl.evaluate(
-            s"""sparkContext.cancelJobGroup("${jobGroupId}")""",
-            msg => sender() ! StreamResponse(msg, "stdout")
+            s"""globalScope.sparkContext.cancelJobGroup("${jobGroupId}")""",
+            msg => thisSender ! StreamResponse(msg, "stdout")
           )
         }
 

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -612,7 +612,7 @@ define([
             var kernel = this.kernel;
             var cancelBtn = $('<a>stop</a>').click(function(){
                 kernel.cancelCellJobs(cell_id);
-                $(this).unbind('click').text('stopping');
+                $(this).text('stopping');
             });
             this.element.find('div.input_prompt')
                 .append($("<br/>"))


### PR DESCRIPTION
- [x] Skip cancelJobGroup for enqueued jobs or when sc not ready
- [x] Use globalScope.sparkContext in scala 2.11
- [x] task may be lost in `currentSessionOperations`(https://github.com/andypetrella/spark-notebook/blob/3985df20ca0e2f0dbe8aeea7f7e97d693f933234/app/notebook/server/CalcWebSocketService.scala#L170-L171) when cancelling a particular non-running cell this might might remove a currently running cell from currentSessionOperations

depends on: https://github.com/andypetrella/spark-notebook/pull/496


@andypetrella 