### PR TITLE
Improve process-next to honour queue

### DIFF
--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -207,8 +207,7 @@ class ReplCalculator(
       case er@ExecuteRequest(_, _, code) =>
         log.debug("Enqueuing execute request at: " + queue.size)
         queue = queue.enqueue((sender(), er))
-        log.debug("Executing execute request")
-        execute(sender(), er)
+        self ! "process-next"
 
       case InterruptCellRequest(killCellId) =>
         // kill job(s) still waiting for execution to start, if any

--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -190,14 +190,13 @@ class ReplCalculator(
     def receive = {
       case "process-next" =>
         log.debug(s"Processing next asked, queue is ${queue.size} length now")
-        if (queue.nonEmpty) {
-          //queue could be empty if InterruptRequest was asked!
+        if (queue.nonEmpty) { //queue could be empty if InterruptRequest was asked!
           log.debug("Dequeuing execute request current size: " + queue.size)
-          queue = queue.dequeue._2
-          queue.headOption foreach { case (ref, er) =>
-            log.debug("About to execute request from the queue")
-            execute(ref, er)
-          }
+          val (executeRequest, queueTail) = queue.dequeue
+          queue = queueTail
+          val (ref, er) = executeRequest
+          log.debug("About to execute request from the queue")
+          execute(ref, er)
         }
 
       case er@ExecuteRequest(_, _, code) if queue.nonEmpty =>

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -213,8 +213,7 @@ class ReplCalculator(
       case er@ExecuteRequest(_, _, code) =>
         log.debug("Enqueuing execute request at: " + queue.size)
         queue = queue.enqueue((sender(), er))
-        log.debug("Executing execute request")
-        execute(sender(), er)
+        self ! "process-next"
 
       case InterruptCellRequest(killCellId) =>
         // kill job(s) still waiting for execution to start, if any

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -199,11 +199,11 @@ class ReplCalculator(
         log.debug(s"Processing next asked, queue is ${queue.size} length now")
         if (queue.nonEmpty) { //queue could be empty if InterruptRequest was asked!
           log.debug("Dequeuing execute request current size: " + queue.size)
-          queue = queue.dequeue._2
-          queue.headOption foreach { case (ref, er) =>
-            log.debug("About to execute request from the queue")
-            execute(ref, er)
-          }
+          val (executeRequest, queueTail) = queue.dequeue
+          queue = queueTail
+          val (ref, er) = executeRequest
+          log.debug("About to execute request from the queue")
+          execute(ref, er)
         }
 
       case er@ExecuteRequest(_, _, code) if queue.nonEmpty =>


### PR DESCRIPTION
- [x] call jobs in consistent way
  * otherwise the first enqueued job would be forcely executed, irrespectively if it's still in the queue or got evicted
- [x] Fix process-next: do not skip elements from the queue
- [x] Update `process-next` for scala 2.11

@andypetrella 