### PR TITLE
Add read only mode

### DIFF
--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -132,7 +132,7 @@
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>
                     <ul id="view_menu" class="dropdown-menu">
                         <li id="report_view">
-                            <a href="?presentation=report" target="_blank">Report (results only)</a>
+                            <a href="?presentation=report&amp;read_only=1" target="_blank">Results only report (read only)</a>
                         </li>
                         <li id="report_view_auto_refresh">
                             <a href="?presentation=report&amp;recompute_now=true" target="_blank">

--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -131,6 +131,11 @@
                 </li>
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>
                     <ul id="view_menu" class="dropdown-menu">
+                        <li id="read_only_view">
+                            <a href="?read_only=1" target="_blank">
+                                Read-only (save resources, no autosave conflicts)
+                            </a>
+                        </li>
                         <li id="report_view">
                             <a href="?presentation=report&amp;read_only=1" target="_blank">Results only report (read only)</a>
                         </li>

--- a/public/ipython/notebook/js/notebook.js
+++ b/public/ipython/notebook/js/notebook.js
@@ -2150,6 +2150,11 @@ define([
         );
     };
 
+    Notebook.prototype.is_read_only = function() {
+        var url = window.location.href;
+        return url.indexOf("read_only=1") != -1;
+    };
+
     /**
      * Success callback for loading a notebook from the server.
      *
@@ -2217,12 +2222,12 @@ define([
         }
         this.set_dirty(false);
         this.scroll_to_top();
-        this.writable = data.writable || false;
+        this.writable = data.writable && !this.is_read_only();
 
         // to save resources eagerly load the kernel only if configured-so in application.conf
         // must automatically start kernel it was requested to recompute the whole notebook immediately
         var recomputeNowRequested = window.location.href.indexOf("recompute_now") != -1;
-        var autoStartKernel = data.autoStartKernel || recomputeNowRequested || false;
+        var autoStartKernel = (data.autoStartKernel || recomputeNowRequested) && this.writable;
         console.log("autoStartKernel on load_notebook: ", autoStartKernel);
 
         var nbmodel = data.content;

--- a/public/ipython/tree/js/notebooklist.js
+++ b/public/ipython/tree/js/notebooklist.js
@@ -304,6 +304,7 @@ define([
         if (model.type == 'file') {
             this.add_delete_button(item);
         } else if (model.type == 'notebook') {
+            this.add_view_button(model, item, path);
             if (this.sessions[path] === undefined){
                 this.add_delete_button(item);
             } else {
@@ -358,6 +359,20 @@ define([
                 return false;
             });
         item.find(".item_buttons").append(shutdown_button);
+    };
+
+    NotebookList.prototype.add_view_button = function (model, item, path) {
+        var uri_prefix = NotebookList.uri_prefixes[model.type];
+        var url = utils.url_join_encode(
+            this.base_url,
+            uri_prefix,
+            path
+        ) + '?read_only=1';
+        var view_button = $("<button/>").text("View (read-only)").addClass("btn btn-warning btn-xs").click(function (e) {
+            window.location.href = url;
+            return false;
+        });
+        item.find(".item_buttons").prepend(view_button);
     };
 
     NotebookList.prototype.add_duplicate_button = function (item) {


### PR DESCRIPTION
- [x] Add `read_only` switch which do not start kernel and prevent saving (related #436 )
- [x] Add to `View` menu
- [x] Add to notebook list

<img width="672" alt="screen shot 2016-01-04 at 15 36 34" src="https://cloud.githubusercontent.com/assets/213426/12090652/9595339a-b2f9-11e5-967d-942b59eaed67.png">


<img width="707" alt="screen shot 2016-01-04 at 15 36 13" src="https://cloud.githubusercontent.com/assets/213426/12090625/60a2fe92-b2f9-11e5-9389-d2d60643a6bd.png">

---

P.S. **to discuss:** should `Results-only view` be read-only by default?!
  *  it is ~nice that even in read only mode, one could start the kernel explicitly and execute stuff there, but without ability to save.  this sounds quite legit.
  * the open question is how to treat the cases when results only view is reactive, e.g. includes some button, so one would expect it to start the `kernel`...

@andypetrella 