### PR TITLE
Automatically highlight the :sql

### DIFF
--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -22,6 +22,7 @@ define([
     'codemirror/lib/codemirror',
     'codemirror/mode/clike/clike',
     'codemirror/mode/python/python',
+    'codemirror/mode/sql/sql',
     'notebook/js/codemirror-ipython'
 ], function(IPython,
     $,
@@ -34,6 +35,7 @@ define([
     celltoolbar,
     CodeMirror,
     cmpython,
+    cm_sql,
     cmip
     ) {
     "use strict";
@@ -144,6 +146,7 @@ define([
             'magic_r'             :{'reg':[/^%%R/]},
             'magic_text/x-cython' :{'reg':[/^%%cython/]},
             'magic_text/x-scala'  :{'reg':[/^%%scala/]},
+            'magic_text/x-sql'    :{'reg':[/^:sql/], 'open': ':'},
         },
     };
 


### PR DESCRIPTION
`:sql` is automatically identified and highlighted after pressing enter

was easy peasy :tada: 


<img width="652" alt="screen shot 2016-01-04 at 19 57 07" src="https://cloud.githubusercontent.com/assets/213426/12096347/6b935c38-b31d-11e5-89b9-cb0f452a63b5.png">

@andypetrella 