### PR TITLE
Simple progressbar per cell

### DIFF
--- a/modules/common/src/main/scala/notebook/front/gadgets/SparkMonitor.scala
+++ b/modules/common/src/main/scala/notebook/front/gadgets/SparkMonitor.scala
@@ -122,6 +122,8 @@ class SparkMonitor(sparkContext:SparkContext, checkInterval:Long = 1000) extends
           "cell_id" → cellId,
           "name" → jobGroup,
           "completed" → (j.completedTasks.toDouble / j.totalTasks * 100),
+          "completed_tasks" -> j.completedTasks,
+          "total_tasks" -> j.totalTasks,
           "duration_millis" → jobDuration,
           "time" → jobDurationStr
         )

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -120,3 +120,7 @@ table.c3-tooltip th {
   margin: 0px 0 10px 0;
   padding: 10px 0 10px 0;
 }
+
+/* cell progress */
+.cell-progress-bar-container { width: 100%; height: 5px; background-color: #f0f0f0; }
+.cell-progress-bar { width: 0; height: 5px; background-color: #369; }

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -170,10 +170,18 @@ define([
         var input = $('<div></div>').addClass('input');
         var prompt = $('<div/>').addClass('prompt input_prompt');
         var inner_cell = $('<div/>').addClass('inner_cell');
+
+        var progress_bar = $('<div></div>').addClass('cell-progress-bar');
+        var progress_container = $('<div></div>')
+          .addClass('cell-progress-bar-container')
+          .append(progress_bar);
+        inner_cell.append(progress_container);
+
         this.celltoolbar = new celltoolbar.CellToolbar({
             cell: this,
             notebook: this.notebook});
         inner_cell.append(this.celltoolbar.element);
+
         var input_area = $('<div/>').addClass('input_area');
         this.code_mirror = new CodeMirror(input_area.get(0), this.cm_config);
         // In case of bugs that put the keyboard manager into an inconsistent state,

--- a/public/javascripts/notebook/job_progress.js
+++ b/public/javascripts/notebook/job_progress.js
@@ -83,7 +83,6 @@ define([
 
         var runningJobs = _.map(_.reject(jobsProgress, isCompleted));
         var runningJobsInfo = _.flatten(_.map(runningJobs, function(p) {
-          console.log("cell_id: " + p.cell_id);
           if (p.cell_id) {
             highlightCell(cells, p.cell_id);
           }
@@ -98,6 +97,17 @@ define([
 
         myChart.data = _.flatten([runningJobsInfo, completedJobsInfo]);
         myChart.draw();
+
+        var perCellId = _.groupBy(jobsProgress, 'cell_id');
+
+        _.each(perCellId, function(jobs, cell_id){
+          var completedTasks = sum(_.pluck(jobs, 'completed_tasks'));
+          var totalTasks = sum(_.pluck(jobs, 'total_tasks'));
+          var cellProgress = Math.floor(completedTasks * 100.0 / totalTasks);
+          if (cell_id) {
+            $(cells[cell_id]).find('.cell-progress-bar').css("width", cellProgress + "%");
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
and here it comes:
<img width="1255" alt="screen shot 2016-01-06 at 17 21 46" src="https://cloud.githubusercontent.com/assets/213426/12146016/1ba348ae-b49a-11e5-8d4f-7f575a7c6bf7.png">

@andypetrella 

some fancy issues for far future:
- [ ] mark running/waiting cells when progress is unknown
- [ ] better estimation of progress?
- [ ] per job stats (not so much needed as we have SparkUI) and/or link to job in spark UI (cell-id may have multiple jobs)
- [ ] change/improve get rid of spark jobs progress based on `dimple`:
  maybe one bar with  something like  `| completed | partially-done | waiting |`