### PR TITLE
Progressbar: Include pending stages and Minor improvements

### DIFF
--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -124,6 +124,6 @@ table.c3-tooltip th {
 /* cell progress */
 .cell-progress-bar-container { width: 100%; height: 5px; background-color: #f0f0f0; }
 .cell-progress-bar { width: 0; height: 5px; background-color: #369; }
-
+.cell-progress-bar.completed { background-color: #bbddbb; }
 
 .prompt { min-width: 7ex; padding: 0 5px 0 0; }

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -91,7 +91,7 @@ td.pvtRendererArea {
 table.c3-tooltip {
   background-color: #ffffff;
 }
-table.c3-tooltip th {
+table.c3-tooltip th, #termDefinitions table th {
   color: #ffffff;
 }
 /* fix the black rect fill appearing in C3 Line charts (looks like a clash with something) */

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -124,3 +124,6 @@ table.c3-tooltip th {
 /* cell progress */
 .cell-progress-bar-container { width: 100%; height: 5px; background-color: #f0f0f0; }
 .cell-progress-bar { width: 0; height: 5px; background-color: #369; }
+
+
+.prompt { min-width: 7ex; padding: 0 5px 0 0; }

--- a/public/javascripts/notebook/job_progress.js
+++ b/public/javascripts/notebook/job_progress.js
@@ -90,9 +90,6 @@ define([
           return [p, pPending]
         }), true);
 
-        myChart.data = _.flatten([runningJobsInfo, completedJobsInfo]);
-        myChart.draw();
-
         var perCellId = _.groupBy(jobsProgress, 'cell_id');
 
         _.each(perCellId, function(jobs, cell_id){
@@ -103,6 +100,10 @@ define([
             $(cells[cell_id]).find('.cell-progress-bar').css("width", Math.max(cellProgress, 5) + "%");
           }
         });
+
+        // redraw chart as last step, in case dimple didn't like some data :)
+        myChart.data = _.flatten([runningJobsInfo, completedJobsInfo]);
+        myChart.draw();
       });
     });
   });

--- a/public/javascripts/notebook/job_progress.js
+++ b/public/javascripts/notebook/job_progress.js
@@ -57,7 +57,6 @@ define([
 
       progress.subscribe(function(status) {
         var cells = findCells();
-        clearHighlightCells(cells);
 
         var jobsProgress = status.jobsStatus;
         var sparkUi = status.sparkUi;
@@ -83,10 +82,6 @@ define([
 
         var runningJobs = _.map(_.reject(jobsProgress, isCompleted));
         var runningJobsInfo = _.flatten(_.map(runningJobs, function(p) {
-          if (p.cell_id) {
-            highlightCell(cells, p.cell_id);
-          }
-
           p.status = "Done";
           // part of stage that's still pending
           pPending = _.clone(p);
@@ -105,7 +100,7 @@ define([
           var totalTasks = sum(_.pluck(jobs, 'total_tasks'));
           var cellProgress = Math.floor(completedTasks * 100.0 / totalTasks);
           if (cell_id) {
-            $(cells[cell_id]).find('.cell-progress-bar').css("width", cellProgress + "%");
+            $(cells[cell_id]).find('.cell-progress-bar').css("width", Math.max(cellProgress, 5) + "%");
           }
         });
       });

--- a/public/javascripts/notebook/job_progress.js
+++ b/public/javascripts/notebook/job_progress.js
@@ -97,7 +97,13 @@ define([
           var totalTasks = sum(_.pluck(jobs, 'total_tasks'));
           var cellProgress = Math.floor(completedTasks * 100.0 / totalTasks);
           if (cell_id) {
-            $(cells[cell_id]).find('.cell-progress-bar').css("width", Math.max(cellProgress, 5) + "%");
+            var cellProgressBar = $(cells[cell_id]).find('.cell-progress-bar')
+            cellProgressBar.css("width", Math.max(cellProgress, 5) + "%");
+            if (cellProgress == 100) {
+              cellProgressBar.addClass("completed")
+            } else {
+              cellProgressBar.removeClass("completed")
+            }
           }
         });
 


### PR DESCRIPTION
* **Include pending stages in progressbar**	98a562e
* make input/output prompt smaller 
* No need to highlight cells on progress
* Mark completed cells in green
* Redraw dimple progresbar as last step (dimple throws exception sometimes)
* increase refresh interval to 2s


<img width="629" alt="screen shot 2016-01-06 at 20 09 58" src="https://cloud.githubusercontent.com/assets/213426/12150388/2cae0d7e-b4b2-11e5-8385-84b31aed983f.png">

