### PR TITLE
Docker image - part 2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val mesosVersion = sys.props.getOrElse("mesos.version", "0.22.0") //0.22.0 is current DCOS version
+  val mesosVersion = sys.props.getOrElse("mesos.version", "0.22.2") //0.22.0 is current DCOS version
 
   val playDeps = Seq(
     "com.typesafe.play" %% "play" % "2.3.7" withSources() excludeAll(

--- a/project/DockerProperties.scala
+++ b/project/DockerProperties.scala
@@ -13,9 +13,9 @@ object DockerProperties extends BuildConf {
 
   private val defaultCommands: Seq[Cmd] = Seq(
     Cmd("USER", "root"),
-    Cmd("RUN", "echo \"deb http://repos.mesosphere.io/ubuntu trusty main\" | tee /etc/apt/sources.list.d/mesosphere.list"),
+    Cmd("RUN", "echo \"deb http://repos.mesosphere.io/debian jessie main\" | tee /etc/apt/sources.list.d/mesosphere.list"),
     Cmd("RUN", "apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF"),
-    Cmd("RUN", s"apt-get update --fix-missing && apt-get install -y openjdk-7-jdk  mesos=$mesosVersion-1.0.ubuntu1404"),
+    Cmd("RUN", s"apt-get update --fix-missing && apt-get install -y --no-install-recommends openjdk-7-jdk mesos=$mesosVersion-0.2.62.debian81"),
     Cmd("ENV", "JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64"),
     Cmd("ENV", s"MESOS_JAVA_NATIVE_LIBRARY /usr/local/lib/libmesos-$mesosVersion.so"),
     Cmd("ENV", s"MESOS_LOG_DIR /var/log/mesos")
@@ -35,7 +35,7 @@ object DockerProperties extends BuildConf {
 
   val maintainer   = getString("docker.maintainer", "Andy Petrella")
 
-  val baseImage    = getString("docker.baseImage", "ubuntu:trusty")
+  val baseImage    = getString("docker.baseImage", "debian:jessie")
 
   val commands     = Try { asCmdSeq(cfg.getConfigList("docker.commands").asScala.toSeq) }.getOrElse( defaultCommands )
   val volumes      = Try { cfg.getStringList("docker.volumes").asScala.toSeq }.getOrElse( defaultVolumes )


### PR DESCRIPTION
@andypetrella This PR changes the os to `debian:jessie` and uses `--no-install-recommends`. These 2 changes bring docker image size down to 1.005GB. It is over 300MB less than before the previous PR (originally the size was ~1.35GB).

The mesos version change should not affect dcos operability because the major mesos version stays the same but I had no chance to test. No need to rush this, it would be great to test beforehand.