### PR TITLE
Repl unit test coverage with minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - SPARK_VER=1.6.0
   # - SPARK_VER=1.3.1 (failing at the moment)
 script:
-  - SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:PermSize=256M -XX:MaxPermSize=512M" sbt -Dspark.version=$SPARK_VER -Dscala.version=$TRAVIS_SCALA_VERSION "set offline := true" test
+  - export SKIP_WHEN_TRAVIS=yes; SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xmx4G -XX:MaxPermSize=4G" sbt -Dspark.version=$SPARK_VER -Dscala.version=$TRAVIS_SCALA_VERSION "set offline := true" test
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm -f

--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -7,6 +7,7 @@ import notebook.OutputTypes._
 import notebook.PresentationCompiler
 import notebook.kernel._
 import notebook.JobTracking
+import notebook.kernel.repl.common.ReplT
 import notebook.util.{CustomResolvers, Deps}
 
 import sbt._
@@ -33,7 +34,6 @@ class ReplCalculator(
   _initScripts: List[(String, String)],
   compilerArgs: List[String]
 ) extends Actor with akka.actor.ActorLogging {
-  val initScripts = _initScripts ::: List(("end", "\"END INIT\""))
 
   private val remoteLogger = context.actorSelection("/user/remote-logger")
   remoteLogger ! remoteActor
@@ -115,9 +115,9 @@ class ReplCalculator(
 
   val ImportsScripts = ("imports", () => customImports.map(_.mkString("\n") + "\n").getOrElse("\n"))
 
-  private var _repl: Option[Repl] = None
+  private var _repl: Option[ReplT] = None
 
-  private def repl: Repl = _repl getOrElse {
+  private def repl: ReplT = _repl getOrElse {
     val r = new Repl(compilerArgs, depsJars)
     _repl = Some(r)
     r
@@ -224,7 +224,7 @@ class ReplCalculator(
         log.debug(s"Interrupting the cell: $killCellId")
         val jobGroupId = JobTracking.jobGroupId(killCellId)
         // make sure sparkContext is already available!
-        if (jobsInQueueToKill.isEmpty && repl.interp.allImportedNames.exists(_.toString == "sparkContext")) {
+        if (jobsInQueueToKill.isEmpty && repl.sparkContextAvailable) {
           log.info(s"Killing job Group $jobGroupId")
           val thisSender = sender()
           repl.evaluate(
@@ -453,7 +453,7 @@ class ReplCalculator(
       """.stripMargin
     )
 
-    def eval(script: () => String): Unit = {
+    def eval(script: () => String): Option[String] = {
       val sc = script()
       log.debug("script is :\n" + sc)
       if (sc.trim.length > 0) {
@@ -461,22 +461,28 @@ class ReplCalculator(
         result match {
           case Failure(str) =>
             log.error("Error in init script: \n%s".format(str))
+            None
           case _ =>
             if (log.isDebugEnabled) log.debug("\n" + sc)
             log.info("Init script processed successfully")
+            Some(sc)
         }
-      } else ()
+      } else None
     }
 
-    val allInitScrips: List[(String, () => String)] = dummyScript :: SparkHookScript :: depsScript :: ImportsScripts :: CustomSparkConfFromNotebookMD :: initScripts.map(
-      x => (x._1, () => x._2))
-    val pc = new PresentationCompiler(depsJars)
+    val allInitScrips: List[(String, () => String)] = dummyScript ::
+                                                      SparkHookScript ::
+                                                      depsScript ::
+                                                      ImportsScripts ::
+                                                      CustomSparkConfFromNotebookMD ::
+                                                      ( _initScripts ::: repl.endInitCommand ).map(x => (x._1, () => x._2))
     for ((name, script) <- allInitScrips) {
       log.info(s" INIT SCRIPT: $name")
-      eval(script)
-      pc.addScripts(script())
+      eval(script).map { sc =>
+        presentationCompiler.addScripts(sc)
+      }
     }
-    _presentationCompiler = Some(pc)
+    repl.setInitFinished()
   }
 
   override def preStart() {
@@ -486,6 +492,7 @@ class ReplCalculator(
 
   override def postStop() {
     log.info("ReplCalculator postStop")
+    presentationCompiler.stop()
     super.postStop()
   }
 

--- a/modules/kernel/src/main/scala/notebook/PresentationCompiler.scala
+++ b/modules/kernel/src/main/scala/notebook/PresentationCompiler.scala
@@ -111,4 +111,8 @@ class PresentationCompiler(dependencies: List[String]) {
       .distinct
     (filterSnippet,returnMatches)
   }
+
+  def stop(): Unit = {
+    compiler.askShutdown()
+  }
 }

--- a/modules/spark/src/main/scala/notebook/kernel/repl/common/ReplShared.scala
+++ b/modules/spark/src/main/scala/notebook/kernel/repl/common/ReplShared.scala
@@ -1,5 +1,10 @@
 package notebook.kernel.repl.common
 
+import java.io.ByteArrayOutputStream
+
+import notebook.kernel.EvaluationResult
+import notebook.util.Match
+
 abstract class NameDefinition {
   def name: String
   def tpe: String
@@ -10,3 +15,45 @@ object NameDefinition {
 }
 case class TypeDefinition(name: String, tpe: String, references: List[String]) extends NameDefinition
 case class TermDefinition(name: String, tpe: String, references: List[String]) extends NameDefinition
+
+class ReplOutputStream extends ByteArrayOutputStream {
+  var aop: String => Unit = x => ()
+
+  override def write(i: Int): Unit = {
+    // CY: Not used...
+    //      orig.value ! StreamResponse(i.toString, "stdout")
+    super.write(i)
+  }
+
+  override def write(bytes: Array[Byte]): Unit = {
+    // CY: Not used...
+    //      orig.value ! StreamResponse(bytes.toString, "stdout")
+    super.write(bytes)
+  }
+
+  override def write(bytes: Array[Byte], off: Int, length: Int): Unit = {
+    val data = new String(bytes, off, length)
+    aop(data)
+    //      orig.value ! StreamResponse(data, "stdout")
+    super.write(bytes, off, length)
+  }
+}
+
+trait ReplT {
+
+  def endInitCommand: List[(String, String)] = List(("end", "\"END INIT\""))
+
+  def addCp(newJars:List[String]): (ReplT, () => Unit)
+  def classServerUri: Option[String]
+  def complete(line: String, cursorPosition: Int): (String, Seq[Match])
+  def evaluate(code: String,
+               onPrintln: String => Unit = _ => (),
+               onNameDefinion: NameDefinition => Unit  = _ => ()
+              ): (EvaluationResult, String)
+  def getTypeNameOfTerm(termName: String): Option[String]
+  def setInitFinished(): Unit
+  def objectInfo(line: String, position:Int): Seq[String]
+  def sparkContextAvailable: Boolean
+  def stop(): Unit
+
+}

--- a/modules/spark/src/main/scala_2.10/spark-last/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-last/notebook/kernel/Repl.scala
@@ -24,41 +24,28 @@ import notebook.util.Match
 import notebook.kernel._
 import notebook.kernel.repl.common._
 
-class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
+class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends ReplT {
   val LOG = org.slf4j.LoggerFactory.getLogger(classOf[Repl])
 
   def this() = this(Nil)
 
-  class MyOutputStream extends ByteArrayOutputStream {
-    var aop: String => Unit = x => ()
+  private lazy val stdoutBytes = new ReplOutputStream
+  private lazy val stdout = new PrintWriter(stdoutBytes)
+  private var loop:HackSparkILoop = _
+  private var _classServerUri:Option[String] = None
 
-    override def write(i: Int): Unit = {
-      // CY: Not used...
-      //      orig.value ! StreamResponse(i.toString, "stdout")
-      super.write(i)
-    }
+  private var _initFinished: Boolean = false
+  private var _evalsUntilInitFinished: Int = 0
+  private var _needsDropOnReplay: Boolean = false
 
-    override def write(bytes: Array[Byte]): Unit = {
-      // CY: Not used...
-      //      orig.value ! StreamResponse(bytes.toString, "stdout")
-      super.write(bytes)
-    }
-
-    override def write(bytes: Array[Byte], off: Int, length: Int): Unit = {
-      val data = new String(bytes, off, length)
-      aop(data)
-      //      orig.value ! StreamResponse(data, "stdout")
-      super.write(bytes, off, length)
-    }
+  def setInitFinished(): Unit = {
+    _initFinished = true
+    _needsDropOnReplay = _evalsUntilInitFinished > 0
   }
 
-
-  private lazy val stdoutBytes = new MyOutputStream
-  private lazy val stdout = new PrintWriter(stdoutBytes)
-
-  private var loop:HackSparkILoop = _
-
-  var classServerUri:Option[String] = None
+  def classServerUri: Option[String] = {
+    _classServerUri
+  }
 
   val interp:org.apache.spark.repl.SparkIMain = {
     val settings = new Settings
@@ -116,7 +103,7 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
       l.interpreter
     }
     //i.initializeSynchronous()
-    classServerUri = Some(i.classServerUri)
+    _classServerUri = Some(i.classServerUri)
     i.asInstanceOf[org.apache.spark.repl.SparkIMain]
   }
 
@@ -149,6 +136,22 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
     candidates map { _.toString } toList
   }
 
+  private def listDefinedTerms(request: interp.Request): List[NameDefinition] = {
+    request.handlers.flatMap { h =>
+      val maybeTerm = h.definesTerm.map(_.encoded)
+      val maybeType = h.definesType.map(_.encoded)
+      val references = h.referencedNames.toList.map(_.encoded)
+      (maybeTerm, maybeType) match {
+        case (Some(term), _) =>
+          val termType = getTypeNameOfTerm(term).getOrElse("<unknown>")
+          Some(TermDefinition(term, termType, references))
+        case (_, Some(tpe)) =>
+          Some(TypeDefinition(tpe, "type", references))
+        case _ => None
+      }
+    }
+  }
+
   def getTypeNameOfTerm(termName: String): Option[String] = {
     val tpe = try {
       interp.typeOfTerm(termName).toString
@@ -165,22 +168,6 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
             .replace("iwC$", "")
             .replaceAll("^\\(\\)" , "") // 2.11 return types prefixed, like `()Person`
         )
-    }
-  }
-
-  def listDefinedTerms(request: interp.Request): List[NameDefinition] = {
-    request.handlers.flatMap { h =>
-      val maybeTerm = h.definesTerm.map(_.encoded)
-      val maybeType = h.definesType.map(_.encoded)
-      val references = h.referencedNames.toList.map(_.encoded)
-      (maybeTerm, maybeType) match {
-        case (Some(term), _) =>
-          val termType = getTypeNameOfTerm(term).getOrElse("<unknown>")
-          Some(TermDefinition(term, termType, references))
-        case (_, Some(tpe)) =>
-          Some(TypeDefinition(tpe, "type", references))
-        case _ => None
-      }
     }
   }
 
@@ -294,18 +281,19 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
       case Error          => Failure(stdoutBytes.toString)
     }
 
+    if ( !_initFinished ) {
+      _evalsUntilInitFinished = _evalsUntilInitFinished + 1
+    }
+
     (result, stdoutBytes.toString)
   }
 
   def addCp(newJars:List[String]) = {
     val requests = interp.getClass.getMethods.find(_.getName == "prevRequestList").map(_.invoke(interp)).get.asInstanceOf[List[interp.Request]]
-
-    val prevCode = requests.map(_.originalLine)
-    val jarList = newJars:::jars
-    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
-    interp.close()
-    val r = new Repl(compilerOpts, jarList)
-    (r, () => prevCode.dropWhile(_.trim != "\"END INIT\"") foreach (c => r.evaluate(c, _ => ())))
+    var prevCode = requests.map(_.originalLine).drop( _evalsUntilInitFinished )
+    interp.close() // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
+    val r = new Repl(compilerOpts, newJars:::jars)
+    (r, () => prevCode foreach (c => r.evaluate(c, _ => ())))
   }
 
   def complete(line: String, cursorPosition: Int): (String, Seq[Match]) = {
@@ -348,12 +336,14 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
     // the thing twice does it give you the method signature (i.e. you
     // hit tab twice).  So we simulate that here... (nutty, I know)
     getCompletions(line, position)
-    val candidates = getCompletions(line, position)
+    getCompletions(line, position)
+  }
 
-    if (candidates.size >= 2 && candidates.head.isEmpty) {
-      candidates.tail
-    } else {
-      Seq.empty
-    }
+  def sparkContextAvailable: Boolean = {
+    interp.allImportedNames.exists(_.toString == "sparkContext")
+  }
+
+  def stop(): Unit = {
+    interp.close()
   }
 }

--- a/modules/spark/src/main/scala_2.11/spark-last/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-last/notebook/kernel/Repl.scala
@@ -3,7 +3,7 @@ package notebook.kernel
 import java.io.{StringWriter, PrintWriter, ByteArrayOutputStream}
 import java.net.{URLDecoder, JarURLConnection}
 import java.util.ArrayList
-import notebook.kernel.repl.common.{TypeDefinition, TermDefinition, NameDefinition}
+import notebook.kernel.repl.common._
 
 import scala.collection.JavaConversions
 import scala.collection.JavaConversions._
@@ -21,41 +21,26 @@ import notebook.util.Match
 import org.apache.spark.SparkConf
 
 
-class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
+class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends ReplT {
   val LOG = org.slf4j.LoggerFactory.getLogger(classOf[Repl])
 
   def this() = this(Nil)
 
-  class MyOutputStream extends ByteArrayOutputStream {
-    var aop: String => Unit = x => ()
+  private lazy val stdoutBytes = new ReplOutputStream
+  private lazy val stdout = new PrintWriter(stdoutBytes)
+  private var loop:org.apache.spark.repl.HackSparkILoop = _
+  private var _classServerUri:Option[String] = None
 
-    override def write(i: Int): Unit = {
-      // CY: Not used...
-      //      orig.value ! StreamResponse(i.toString, "stdout")
-      super.write(i)
-    }
+  private var _initFinished: Boolean = false
+  private var _evalsUntilInitFinished: Int = 0
 
-    override def write(bytes: Array[Byte]): Unit = {
-      // CY: Not used...
-      //      orig.value ! StreamResponse(bytes.toString, "stdout")
-      super.write(bytes)
-    }
-
-    override def write(bytes: Array[Byte], off: Int, length: Int): Unit = {
-      val data = new String(bytes, off, length)
-      aop(data)
-      //      orig.value ! StreamResponse(data, "stdout")
-      super.write(bytes, off, length)
-    }
+  def setInitFinished(): Unit = {
+    _initFinished = true
   }
 
-
-  private lazy val stdoutBytes = new MyOutputStream
-  private lazy val stdout = new PrintWriter(stdoutBytes)
-
-  private var loop:org.apache.spark.repl.HackSparkILoop = _
-
-  var classServerUri:Option[String] = None
+  def classServerUri: Option[String] = {
+    _classServerUri
+  }
 
   val interp = {
     val settings = new Settings
@@ -124,7 +109,7 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
     }
 
     loop.process(settings)
-    classServerUri = Some(loop.classServer.uri)
+    _classServerUri = Some(loop.classServer.uri)
     loop.intp
   }
 
@@ -157,6 +142,22 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
     candidates map { _.toString } toList
   }
 
+  private def listDefinedTerms(request: interp.Request): List[NameDefinition] = {
+    request.handlers.flatMap { h =>
+      val maybeTerm = h.definesTerm.map(_.encoded)
+      val maybeType = h.definesType.map(_.encoded)
+      val references = h.referencedNames.toList.map(_.encoded)
+      (maybeTerm, maybeType) match {
+        case (Some(term), _) =>
+          val termType = getTypeNameOfTerm(term).getOrElse("<unknown>")
+          Some(TermDefinition(term, termType, references))
+        case (_, Some(tpe)) =>
+          Some(TypeDefinition(tpe, "type", references))
+        case _ => None
+      }
+    }
+  }
+
 
   def getTypeNameOfTerm(termName: String): Option[String] = {
     val tpe = try {
@@ -174,22 +175,6 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
           .replace("iwC$", "")
           .replaceAll("^\\(\\)" , "") // 2.11 return types prefixed, like `()Person`
         )
-    }
-  }
-
-  def listDefinedTerms(request: interp.Request): List[NameDefinition] = {
-    request.handlers.flatMap { h =>
-      val maybeTerm = h.definesTerm.map(_.encoded)
-      val maybeType = h.definesType.map(_.encoded)
-      val references = h.referencedNames.toList.map(_.encoded)
-      (maybeTerm, maybeType) match {
-        case (Some(term), _) =>
-          val termType = getTypeNameOfTerm(term).getOrElse("<unknown>")
-          Some(TermDefinition(term, termType, references))
-        case (_, Some(tpe)) =>
-          Some(TypeDefinition(tpe, "type", references))
-        case _ => None
-      }
     }
   }
 
@@ -309,15 +294,18 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
       case Error          => Failure(stdoutBytes.toString)
     }
 
+    if ( !_initFinished ) {
+      _evalsUntilInitFinished = _evalsUntilInitFinished + 1
+    }
+
     (result, stdoutBytes.toString)
   }
 
   def addCp(newJars:List[String]) = {
-    val prevCode = interp.prevRequestList.map(_.originalLine)
-    // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
-    interp.close()
+    val prevCode = interp.prevRequestList.map(_.originalLine).drop( _evalsUntilInitFinished )
+    interp.close() // this will close the repl class server, which is needed in order to reuse `-Dspark.replClassServer.port`!
     val r = new Repl(compilerOpts, newJars:::jars)
-    (r, () => prevCode.drop(7/*init scripts... → UNSAFE*/) foreach (c => r.evaluate(c, _ => ())))
+    (r, () => prevCode foreach (c => r.evaluate(c, _ => ())))
   }
 
   def complete(line: String, cursorPosition: Int): (String, Seq[Match]) = {
@@ -360,12 +348,14 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) {
     // the thing twice does it give you the method signature (i.e. you
     // hit tab twice).  So we simulate that here... (nutty, I know)
     getCompletions(line, position)
-    val candidates = getCompletions(line, position)
+    getCompletions(line, position)
+  }
 
-    if (candidates.size >= 2 && candidates.head.isEmpty) {
-      candidates.tail
-    } else {
-      Seq.empty
-    }
+  def sparkContextAvailable: Boolean = {
+    interp.allImportedNames.exists(_.toString == "sparkContext")
+  }
+
+  def stop(): Unit = {
+    interp.close()
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -136,6 +136,7 @@ object Dependencies {
         case hvr("2", x) if x.toInt >= 3 => "0.9.0"
         case _ => defaultJets3tVersion
       }
+      case _ => defaultJets3tVersion
     }
     "net.java.dev.jets3t" % "jets3t" % v force() excludeAll ExclusionRule()
   }

--- a/test/notebook/PresentationCompilerTests.scala
+++ b/test/notebook/PresentationCompilerTests.scala
@@ -7,6 +7,7 @@ import org.specs2.runner._
 
 @RunWith(classOf[JUnitRunner])
 class PresentationCompilerTests extends Specification {
+
   def complete(pc:PresentationCompiler)(s:String, i:Int) = {
     val (st, com) = pc.complete(s, i)
     (st, com.toSet)
@@ -40,10 +41,12 @@ class PresentationCompilerTests extends Specification {
         Match("toSchwarz", Map("display_text" -> "toSchwarz: Float")),
         Match("toString", Map("display_text" -> "toString: String"))
       ))
-      c(code + "\nval testAsSt$ring = test.toString()", code.size) must beEqualTo("toS", Set(
+      val r = c(code + "\nval testAsSt$ring = test.toString()", code.size) must beEqualTo("toS", Set(
         Match("toSchwarz", Map("display_text" -> "toSchwarz: Float")),
         Match("toString", Map("display_text" -> "toString: String"))
       ))
+      pc.stop()
+      r
     }
 
     "lists all overrided method versions, indicating optional parameters if any" in {
@@ -54,12 +57,14 @@ class PresentationCompilerTests extends Specification {
       pc.addScripts(cz)
       val c = complete(pc) _
 
-      c(code, code.size) must beEqualTo("testMeth", Set(
+      val r = c(code, code.size) must beEqualTo("testMeth", Set(
         Match("testMethod(a: Int, [optionalB: String])",
           Map("display_text" -> "testMethod(a: Int, [optionalB: String]): String")),
         Match("testMethod(a: String)", Map("display_text" -> "testMethod(a: String): String")),
         Match("testMethod(a: String, b: String)", Map("display_text" -> "testMethod(a: String, b: String): String"))
       ))
+      pc.stop()
+      r
     }
 
     "lists the methods inherited and the implicit methods" in {
@@ -72,7 +77,7 @@ class PresentationCompilerTests extends Specification {
       val suggestions: Set[String] = c(code1, code1.size)._2.map {case Match(s, _) => s }
       println(suggestions.map(s=> s""""${s}""""))
 
-      suggestions must containAllOf(Seq(
+      val r = suggestions must containAllOf(Seq(
         "+(other: String)",
         "clone",
         "hashCode",
@@ -81,6 +86,9 @@ class PresentationCompilerTests extends Specification {
         "isInstanceOf",
         "implicitMethod(a: Int)"
       ))
+
+      pc.stop()
+      r
     }
   }
 }

--- a/test/repl/ReplTests.scala
+++ b/test/repl/ReplTests.scala
@@ -1,0 +1,109 @@
+package repl
+
+import notebook.kernel.repl.common.ReplT
+import notebook.kernel.{Failure, Incomplete, Success, Repl}
+import notebook.util.Match
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import utils.BeforeAllAfterAll
+
+@RunWith(classOf[JUnitRunner])
+class ReplTests extends Specification with BeforeAllAfterAll {
+
+  var repl: ReplT = _
+  def beforeAll = repl = new Repl()
+  def afterAll = repl.stop()
+
+  "fail when attempting to use undefined code" in {
+    repl.evaluate("val x = new NotDefinedClass") match {
+      case ( Failure(_), _ ) => success
+      case _ => failure("Expected Failure from evaluation")
+    }
+  }
+
+  "fail with incomplete code" in {
+    repl.evaluate("case class ReplTestClass(va") match {
+      case ( Incomplete, _ ) => success
+      case _ => failure("Expected Incomplete from evaluation")
+    }
+  }
+
+  "successfully evaluate coplete code" in {
+    repl.evaluate("case class ReplTestClass(val x:Int)") match {
+      case ( Success(_), _ ) => success
+      case _ => failure("Expected Success from evaluation")
+    }
+  }
+
+  "return a type name of defined term" in {
+    repl.evaluate("case class ReplTestClassGetTypeName(val x:Int); val x = new ReplTestClassGetTypeName(5)") match {
+      case ( Success(_), _ ) =>
+        repl.getTypeNameOfTerm("x") match {
+          case None =>
+            failure("Expected Some type name")
+          case Some(typeName) =>
+            typeName must contain("ReplTestClassGetTypeName")
+            success
+        }
+      case _ =>
+        failure("Expected Success from evaluation")
+    }
+  }
+
+  "return object information for code" in {
+    var code =
+      """
+        |case class ReplTestClassInformation(val prop:Int) {
+        |  def dummy: Int = prop
+        |}
+        |val x = new ReplTestClassInformation(5)
+      """.stripMargin
+    repl.evaluate(code) match {
+      case ( Success(_), _ ) =>
+        repl.objectInfo("x.du", 4) must beEqualTo( List("dummy") )
+        success
+      case _ =>
+        failure("Expected Success from evaluation")
+    }
+  }
+
+  "return completed line for code" in {
+    var code =
+      """
+        |case class ReplTestClassCompletion(val prop:Int) {
+        |  def dummy: Int = prop
+        |}
+        |val x = new ReplTestClassCompletion(5)
+      """.stripMargin
+    repl.evaluate(code) match {
+      case ( Success(_), _ ) =>
+        var completed = repl.complete("x.du", 4)
+        completed must beEqualTo( ("du", List( Match("dummy", Map.empty[String, String]) ) ) )
+        success
+      case _ =>
+        failure("Expected Success from evaluation")
+    }
+  }
+
+  "adding a jar must keep defined code intact" in {
+    if ( sys.env.contains("SKIP_WHEN_TRAVIS") ) {
+      skipped(": Test skipped on TravisCI, causes OOM.")
+    } else {
+      val privRepl = new Repl()
+      privRepl.evaluate("case class MyTestClassToKeep()")
+      val replInit = privRepl.addCp(List.empty[String])
+      val newRepl = replInit._1
+      replInit._2.apply() // calls the replay logic on the new repl...
+      val res = newRepl.evaluate("val x = new MyTestClassToKeep") match {
+        case (Success(_), _) =>
+          success
+        case ex =>
+          failure(s"Expected Success from evaluation but received $ex")
+      }
+      newRepl.stop()
+      res
+    }
+  }
+
+}

--- a/test/utils/BeforeAllAfterAll.scala
+++ b/test/utils/BeforeAllAfterAll.scala
@@ -1,0 +1,13 @@
+package utils
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.{Fragments, Step}
+
+trait BeforeAllAfterAll extends Specification {
+  // see http://bit.ly/11I9kFM (specs2 User Guide)
+  override def map(fragments: =>Fragments) =
+    Step(beforeAll) ^ fragments ^ Step(afterAll)
+
+  protected def beforeAll()
+  protected def afterAll()
+}


### PR DESCRIPTION
Hi @andypetrella,

I've created unit tests for `Repl`. While working on these I found out that the `addCp` method did not work correctly for the replay functionality. Classes defined before adding dependencies would not exist after `addCp` was called. This appears to be fixed. It can only be tested from the user interface as, unfortunately, `ReplCalculator` is not unit testable (1).

While adding these unit tests I also stumbled upon the problem with `PresentationController` tests causing JVM `GC overhead limit exceeded`. I have added stop method to the class to resolve the problem.

(1): The `ReplCalculator` actor requires notebook server jars to exist on the class path in order to run `init.sc` script. This jar is not available in the unit tests so the `init.sc` can't be executed. It is not possible to create `SparkContext` either because there is no separate spark jars - classes are embedded in the uberjar. I'd consider refactoring `ReplCalculator` to have all the logic of processing input (accepting `ExecuteRequest` and forwarding it to `repl`) separate from initialisation.