### PR TITLE
Protect from an exception in case of uploading files other than notebooks.

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -521,9 +521,8 @@ object Application extends Controller {
     val path = URLDecoder.decode(p, UTF_8)
     Logger.info("SAVE → " + path)
 
-    val data = (request.body \ "content")
     Try {
-      val notebookJsObject = data.asInstanceOf[JsObject]
+      val notebookJsObject = (request.body \ "content").asInstanceOf[JsObject]
       NBSerializer.fromJson(notebookJsObject) match {
         case Some(notebook) =>
           Try {

--- a/app/notebook/NBSerializer.scala
+++ b/app/notebook/NBSerializer.scala
@@ -227,15 +227,19 @@ object NBSerializer {
 
   implicit val notebookFormat = Json.format[Notebook]
 
-  def fromJson(json: JsValue): Notebook = {
+  def fromJson(json: JsValue): Option[Notebook] = {
     Logger.trace("\r\n**************************************\r\n")
     Logger.trace(Json.prettyPrint(json))
     Logger.trace("**************************************\r\n")
     json.validate[Notebook] match {
       case s: JsSuccess[Notebook] => {
-        val notebook: Notebook = s.get
-        val nb = notebook.cells.map { _ => notebook } getOrElse notebook.copy(cells = Some(Nil))
-        nb
+        s.get match {
+          case Notebook(None,None,None,None,None) =>
+            Logger.warn("Nothing in the notebook data.")
+            None
+          case notebook =>
+            Some( notebook.cells.map { _ => notebook } getOrElse notebook.copy(cells = Some(Nil)) )
+        }
       }
       case e: JsError => {
         val ex = new RuntimeException(Json.stringify(JsError.toFlatJson(e)))
@@ -245,11 +249,8 @@ object NBSerializer {
     }
   }
 
-  def read(s: String): Notebook = {
-    //Logger.info("Reading Notebook")
-    //Logger.info(s)
-    val json: JsValue = Json.parse(s)
-    fromJson(json)
+  def read(s: String): Option[ Notebook ] = {
+    fromJson(Json.parse(s))
   }
 
   def write(n: Notebook): String = {

--- a/app/notebook/server/NotebookManager.scala
+++ b/app/notebook/server/NotebookManager.scala
@@ -79,9 +79,13 @@ class NotebookManager(val name: String, val notebookDir: File) {
     nbData.map { nb =>
       val newPath = incrementFileName(nb._4.dropRight(extension.length))
       val newName = getName(newPath)
-      val oldNB = NBSerializer.read(nb._3)
-      save(newPath, Notebook(oldNB.metadata.map(_.copy(name = newName)), oldNB.cells, oldNB.worksheets, oldNB.autosaved, None), false)
-      newPath
+      NBSerializer.read(nb._3) match {
+        case Some(oldNB) =>
+          save(newPath, Notebook(oldNB.metadata.map(_.copy(name = newName)), oldNB.cells, oldNB.worksheets, oldNB.autosaved, None), false)
+          newPath
+        case None =>
+          newNotebook()
+      }
     } getOrElse newNotebook()
   }
 
@@ -138,7 +142,7 @@ class NotebookManager(val name: String, val notebookDir: File) {
     Logger.info(s"Loading notebook at path $path")
     val file = notebookFile(path)
     if (file.exists())
-      Some(NBSerializer.read(FileUtils.readFileToString(file)))
+      NBSerializer.read(FileUtils.readFileToString(file))
     else
       None
   }

--- a/public/ipython/tree/js/notebooklist.js
+++ b/public/ipython/tree/js/notebooklist.js
@@ -520,6 +520,19 @@ define([
                     that.session_list.load_sessions();
                 };
 
+                var on_error = function(e) {
+                    dialog.modal({
+                        title : 'Cannot upload the file',
+                        body : "The error was: " + e.xhr.responseText,
+                        buttons : {'OK' : {
+                            'class' : 'btn-primary',
+                            click: function () {
+                                item.remove();
+                            }
+                        }}
+                    });
+                }
+
                 var exists = false;
                 $.each(that.element.find('.list_item:not(.new-file)'), function(k,v){
                     if ($(v).data('name') === filename) { exists = true; return false; }
@@ -533,7 +546,7 @@ define([
                             Overwrite : {
                                 class: "btn-danger",
                                 click: function () {
-                                    that.contents.save(path, model).then(on_success);
+                                    that.contents.save(path, model).then(on_success).catch(on_error);
                                 }
                             },
                             Cancel : {
@@ -542,7 +555,7 @@ define([
                         }
                     });
                 } else {
-                    that.contents.save(path, model).then(on_success);
+                    that.contents.save(path, model).then(on_success).catch(on_error);
                 }
 
                 return false;


### PR DESCRIPTION
@andypetrella it appears that the server treats everything on the list as if it was a notebook. This it would be great to not allow uploading files which can't be parsed to notebooks. This PR adds that sort of protection. There is obviously more that could be done on the front end side but the back end side is probably more important.