### PR TITLE
Kill kernel automatically

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -46,6 +46,7 @@ object Application extends Controller {
   val project = nbm.name
   val base_project_url = current.configuration.getString("application.context").getOrElse("/")
   val autoStartKernel = current.configuration.getBoolean("manager.kernel.autostartOnNotebookOpen").getOrElse(true)
+  val kernelKillTimeout = current.configuration.getMilliseconds("manager.kernel.killTimeout")
   val base_kernel_url = "/"
   val base_observable_url = "observable"
   val read_only = false.toString
@@ -193,7 +194,8 @@ object Application extends Controller {
         initScripts,
         compilerArgs,
         kernel.remoteDeployFuture,
-        config.tachyonInfo
+        config.tachyonInfo,
+        kernelTimeout = kernelKillTimeout
       )
       kernelIdToCalcService += kId -> service
       (kId, kernel, service)

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -193,7 +193,7 @@ object Application extends Controller {
         customSparkConf,
         initScripts,
         compilerArgs,
-        kernel.remoteDeployFuture,
+        kernel,
         config.tachyonInfo,
         kernelTimeout = kernelKillTimeout
       )
@@ -449,7 +449,6 @@ object Application extends Controller {
     KernelManager.get(kernelId).foreach { k =>
       Logger.info(s"Closing kernel $kernelId")
       k.shutdown()
-      KernelManager.remove(kernelId)
     }
   }
 

--- a/app/notebook/server/CalcWebSocketService.scala
+++ b/app/notebook/server/CalcWebSocketService.scala
@@ -3,6 +3,7 @@ package notebook.server
 import akka.actor.{Terminated, _}
 import notebook.client._
 import notebook.kernel.repl.common.{NameDefinition, TermDefinition, TypeDefinition}
+import org.joda.time.LocalTime
 import play.api._
 import play.api.libs.json.Json.{obj, arr}
 import play.api.libs.json._
@@ -28,7 +29,8 @@ class CalcWebSocketService(
   initScripts: List[(String, String)],
   compilerArgs: List[String],
   remoteDeployFuture: Future[Deploy],
-  tachyonInfo: Option[notebook.server.TachyonInfo]) {
+  tachyonInfo: Option[notebook.server.TachyonInfo],
+  kernelTimeout: Option[Long]) {
 
   implicit val executor = system.dispatcher
 
@@ -43,6 +45,9 @@ class CalcWebSocketService(
     var calculator: ActorRef = null
     var wss: List[WebSockWrapper] = Nil
 
+    protected val notebookStartTime = LocalTime.now()
+    private var lastCellExecutionTime: Option[LocalTime] = None
+
     val ws = new {
       def send(header: JsValue, session: JsValue /*ignored*/ , msgType: String, channel: String,
         content: JsValue) = {
@@ -50,6 +55,28 @@ class CalcWebSocketService(
         wss.foreach { ws =>
           ws.send(header, ws.session, msgType, channel, content)
         }
+      }
+    }
+
+    private def markNotebookAsActive() = {
+      lastCellExecutionTime = Some(LocalTime.now)
+    }
+
+    protected def isKernelTimeouted = {
+      val lastActionTime = lastCellExecutionTime match {
+        case Some(lastExec) => lastExec
+        case None => notebookStartTime
+      }
+      kernelTimeout.exists { kernelTimeoutMillis =>
+        lastActionTime.plusMillis(kernelTimeoutMillis.toInt).isBefore(LocalTime.now())
+      }
+    }
+
+    // if no cell was being executed for configured threshold interval, kill the kernel
+    context.system.scheduler.schedule(initialDelay = 1.minutes, interval = 1.minutes) {
+      if (isKernelTimeouted) {
+        log.warning("Killing a timeouted kernel")
+        calculator ! PoisonPill
       }
     }
 
@@ -137,6 +164,7 @@ class CalcWebSocketService(
         val operations = new SessionOperationActors(header, session)
         val (operationActor, cellId) = (request: @unchecked) match {
           case ExecuteRequest(cellId, counter, code) =>
+            markNotebookAsActive()
             ws.send(header, session, "status", "iopub", obj("execution_state" → "busy"))
             ws.send(header, session, "pyin", "iopub", obj("cell_id" → cellId, "execution_count" → counter, "code" → code))
             (operations.singleExecution(cellId, counter), Some(cellId))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -95,6 +95,10 @@ manager {
 
   kernel {
     ###
+    # Uncomment to kill kernel after inactivity timeout
+    # killTimeout = 60 minute
+
+    ###
     # Uncomment to not to start the kernel (spark-context) automatically when notebook was open
     ## autostartOnNotebookOpen = false
 

--- a/modules/subprocess/src/main/scala/notebook/Kernel.scala
+++ b/modules/subprocess/src/main/scala/notebook/Kernel.scala
@@ -54,16 +54,18 @@ class Kernel(
       remoteDeployPromise.success(remoteInfo.deploy)
     }
 
+    def shutdownRemote() = {
+      Option(remoteInfo).foreach(_.shutdownRemote())
+      KernelManager.remove(kernelId)
+    }
+
     override def postStop() {
-      if (remoteInfo != null)
-        remoteInfo.shutdownRemote()
+      shutdownRemote()
     }
 
     def receive = {
       case ShutdownNow =>
-        if (remoteInfo != null) {
-          remoteInfo.shutdownRemote()
-        }
+        shutdownRemote()
     }
   }
 


### PR DESCRIPTION
- [x] Configure timeout, and figure out when timeout has passed
- [x] Kernel after timeout (but maybe there is a  better way?)
- [x] Info that kernel was killed should be propagated to `Application`, so `#running` notebooks shows correct info!!!
  * I wouldn't be surprised if `#running` was showing wrong info, if kernel died because say `OutOfMemmory`....
    * `KernelManager.remove(kernelId) && kernelIdToCalcService -= kernelId` happens only here https://github.com/andypetrella/spark-notebook/blob/master/app/controllers/Application.scala#L450
  * any good suggestions here?


@andypetrella @meh-ninja 