### PR TITLE
Refactor code-cell UI & progressbar

### DIFF
--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -121,9 +121,27 @@ table.c3-tooltip th, #termDefinitions table th {
   padding: 10px 0 10px 0;
 }
 
-/* cell progress */
-.cell-progress-bar-container { width: 100%; height: 5px; background-color: #f0f0f0; }
-.cell-progress-bar { width: 0; height: 5px; background-color: #369; }
-.cell-progress-bar.completed { background-color: #bbddbb; }
+/* cell progress: based on http://getbootstrap.com/components/#progress-animated */
+.progress { margin: 0; }
+div.progress-bar { text-align: left; }
+div.progress-bar a.cancel-cell-btn { font-weight: bold; color: #336699 !important; margin-left: 10px; }
+div.progress-bar.active a.cancel-cell-btn { color: #FFFFFF!important; }
 
-.prompt { min-width: 7ex; padding: 0 5px 0 0; }
+.prompt { display: none; visibility: hidden; }
+/* new cell UI */
+div.cell.code_cell {
+  border: 2px solid #c1c1c1;
+  border-radius: 5px;
+  padding: 0;
+  margin-bottom: 10px;
+}
+
+.code_cell div.input_area {
+  border-right-width: 0;
+  border-bottom-width: 0;
+  border-top-width: 0;
+  border-left-width: 5px;
+  background: transparent;
+}
+/* make defined variables lighter, so it do not disturb from final result */
+div.output_area pre { color: #666; }

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -171,11 +171,12 @@ define([
         var prompt = $('<div/>').addClass('prompt input_prompt');
         var inner_cell = $('<div/>').addClass('inner_cell');
 
-        var progress_bar = $('<div></div>').addClass('cell-progress-bar');
-        var progress_container = $('<div></div>')
-          .addClass('cell-progress-bar-container')
-          .append(progress_bar);
-        inner_cell.append(progress_container);
+        var progress_container = $('\
+        <div class="progress">\
+          <div class="progress-bar" role="progressbar" aria-valuenow="" \
+               aria-valuemin="0" aria-valuemax="100">\
+          </div>\
+        </div>');
 
         this.celltoolbar = new celltoolbar.CellToolbar({
             cell: this,
@@ -228,7 +229,7 @@ define([
             .appendTo(widget_prompt);
 
         var output = $('<div></div>');
-        cell.append(input).append(widget_area).append(output);
+        cell.append(input).append(widget_area).append(output).append(progress_container);
         this.element = cell;
         this.output_area = new outputarea.OutputArea({
             selector: output,
@@ -610,6 +611,19 @@ define([
 
     CodeCell.input_prompt_function = CodeCell.input_prompt_compact;
 
+    CodeCell.prototype.addCancelCellBtn = function() {
+        var cell_id = this.cell_id;
+        var kernel = this.kernel;
+        var cancelBtn = $('<a class="cancel-cell-btn">stop</a>').click(function(){
+            kernel.cancelCellJobs(cell_id);
+            $(this).text('stopping');
+        });
+        this.element.find('div.progress-bar').html(cancelBtn);
+    };
+
+    CodeCell.prototype.hideCancelCellBtn = function() {
+        this.element.find('div.progress-bar').removeClass('active').css('width', '');
+    };
 
     CodeCell.prototype.set_input_prompt = function (number) {
         var nline = 1;
@@ -621,17 +635,12 @@ define([
         // This HTML call is okay because the user contents are escaped.
         this.element.find('div.input_prompt').html(prompt_html);
 
-        // if it's running currently, add a 'cancel' button
+        // if it's running currently, add a 'cancel' button inside the progress bar
         if (number === '*') {
-            var cell_id = this.cell_id;
-            var kernel = this.kernel;
-            var cancelBtn = $('<a>stop</a>').click(function(){
-                kernel.cancelCellJobs(cell_id);
-                $(this).text('stopping');
-            });
-            this.element.find('div.input_prompt')
-                .append($("<br/>"))
-                .append(cancelBtn);
+            this.addCancelCellBtn();
+        } else {
+            this.element.find('.cancel-cell-btn').hide();
+            this.hideCancelCellBtn();
         }
     };
 

--- a/public/javascripts/notebook/job_progress.js
+++ b/public/javascripts/notebook/job_progress.js
@@ -83,12 +83,14 @@ define([
           var totalTasks = sum(_.pluck(jobs, 'total_tasks'));
           var cellProgress = Math.min(Math.floor(completedTasks * 100.0 / totalTasks), 100);
           if (cell_id) {
-            var cellProgressBar = $(cells[cell_id]).find('.cell-progress-bar');
+            var cellProgressBar = $(cells[cell_id]).find('div.progress-bar');
             cellProgressBar.css("width", Math.max(cellProgress, 5) + "%");
             if (cellProgress == 100) {
-              cellProgressBar.addClass("completed")
+              cellProgressBar.removeClass("active").removeClass("progress-bar-striped");
+              // cellProgressBar.find('.cancel-cell-btn').hide();
             } else {
-              cellProgressBar.removeClass("completed")
+              cellProgressBar.addClass("active").addClass("progress-bar-striped");
+              cellProgressBar.find('.cancel-cell-btn').show();
             }
           }
         });

--- a/public/stylesheets/ipython/css/reportmode_notebook.css
+++ b/public/stylesheets/ipython/css/reportmode_notebook.css
@@ -8,10 +8,11 @@
 /* hide stdout, and sidebar (progress bar etc) */
 .output_prompt, .output_stdout, #progress-pies, #sidebar { visibility: hidden !important; display: none !important; }
 
-/* hide inputs (code) */
-.input, .input_prompt { visibility: hidden !important; display: none !important; }
+/* hide inputs (code), and cell progressbar */
+.input, .input_prompt, .cell.code_cell div.progress { visibility: hidden !important; display: none !important; }
 
 /* make the selected cell look the same as others */
 .cell.selected { border: none; }
+div.cell.code_cell { border: none!important; }
 
 div:empty { display: none !important; }


### PR DESCRIPTION
- add border around code cell and remove distracting elements
- use progressbar from `bootstrap`
- move stop button inside progressbar

@andypetrella @meh-ninja 

might need some more love and general refactoring later, but what we get is this:
<img width="629" alt="screen shot 2016-01-12 at 16 29 52" src="https://cloud.githubusercontent.com/assets/213426/12266268/e13c5f10-b94a-11e5-858b-07db6c71603d.png">

P.S. this removes the cell sequential number for now. if you like it we could think where to put it in NON-distracting way...