### PR TITLE
Simplify total progress bar

### DIFF
--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -335,7 +335,7 @@
                 <ul>
                     <li data-row="1" data-col="1" data-sizex="2" data-sizey="1" id="spark-job-progress-panel">
                         <h4>Spark Job Progress&nbsp;&nbsp;<span id="spark-ui-link-container"></span></h4>
-                        <div id="progress-pies"></div>
+                        <div id="all-jobs-progress-bar"></div>
                     </li>
 
                     <li data-row="2" data-col="1" data-sizex="2" data-sizey="1">

--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -333,12 +333,10 @@
           <div id="notebook-panels" class="col-md-3" >
             <div id="sidebar" class="gridster">
                 <ul>
-                    <li data-row="1" data-col="1" data-sizex="2" data-sizey="1" id="spark-job-progress-panel">
-                        <h4>Spark Job Progress&nbsp;&nbsp;<span id="spark-ui-link-container"></span></h4>
+                    <li data-row="2" data-col="1" data-sizex="2" data-sizey="2">
+                        <h4 id="spark-jobs">Spark Job Progress&nbsp;&nbsp;<span id="spark-ui-link-container"></span></h4>
                         <div id="all-jobs-progress-bar"></div>
-                    </li>
 
-                    <li data-row="2" data-col="1" data-sizex="2" data-sizey="1">
                         <h4>Terms defined</h4>
                         <div id="termDefinitions" style="overflow: auto; height: 200px"></div>
                     </li>

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -127,6 +127,9 @@ div.progress-bar { text-align: left; }
 div.progress-bar a.cancel-cell-btn { font-weight: bold; color: #336699 !important; margin-left: 10px; }
 div.progress-bar.active a.cancel-cell-btn { color: #FFFFFF!important; }
 
+#all-jobs-progress-bar { margin-bottom: 20px; }
+h4#spark-jobs { margin-bottom: 0 !important; }
+
 .prompt { display: none; visibility: hidden; }
 /* new cell UI */
 div.cell.code_cell {


### PR DESCRIPTION

<img width="326" alt="screen shot 2016-01-12 at 18 56 25" src="https://cloud.githubusercontent.com/assets/213426/12270331/3bd96b26-b95e-11e5-9f9a-e334762ee429.png">

would be good to get rid of the not-used space too (don't look simple with this gridster...)...

@andypetrella @meh-ninja 