### PR TITLE
Fix codemirror/scala anonymous fn indentation

### DIFF
--- a/public/ipython/components/codemirror/mode/clike/clike.js
+++ b/public/ipython/components/codemirror/mode/clike/clike.js
@@ -11,6 +11,26 @@
 })(function(CodeMirror) {
 "use strict";
 
+function Context(indented, column, type, align, prev) {
+  this.indented = indented;
+  this.column = column;
+  this.type = type;
+  this.align = align;
+  this.prev = prev;
+}
+function pushContext(state, col, type) {
+  var indent = state.indented;
+  if (state.context && state.context.type == "statement")
+    indent = state.context.indented;
+  return state.context = new Context(indent, col, type, null, state.context);
+}
+function popContext(state) {
+  var t = state.context.type;
+  if (t == ")" || t == "]" || t == "}")
+    state.indented = state.context.indented;
+  return state.context = state.context.prev;
+}
+
 CodeMirror.defineMode("clike", function(config, parserConfig) {
   var indentUnit = config.indentUnit,
       statementIndentUnit = parserConfig.statementIndentUnit || indentUnit,
@@ -95,26 +115,6 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
       maybeEnd = (ch == "*");
     }
     return "comment";
-  }
-
-  function Context(indented, column, type, align, prev) {
-    this.indented = indented;
-    this.column = column;
-    this.type = type;
-    this.align = align;
-    this.prev = prev;
-  }
-  function pushContext(state, col, type) {
-    var indent = state.indented;
-    if (state.context && state.context.type == "statement")
-      indent = state.context.indented;
-    return state.context = new Context(indent, col, type, null, state.context);
-  }
-  function popContext(state) {
-    var t = state.context.type;
-    if (t == ")" || t == "]" || t == "}")
-      state.indented = state.context.indented;
-    return state.context = state.context.prev;
   }
 
   // Interface

--- a/public/ipython/components/codemirror/mode/clike/clike.js
+++ b/public/ipython/components/codemirror/mode/clike/clike.js
@@ -394,6 +394,16 @@ CodeMirror.defineMode("clike", function(config, parserConfig) {
         stream.eatWhile(/[\w\$_]/);
         return "meta";
       },
+      "{": function(stream, state) {
+        // match single full line params of anonymous fn:
+        // { a =>\n
+        // { (aa: Int, bb: Int) =>\n
+        var singleLineParams = /^(\w|[:.,() ])+=>$/;
+        if (!stream.match(singleLineParams, true)) // eat the line, if matches
+          return false;
+        pushContext(state, stream.column(), "}");
+        return null;
+      },
       '"': function(stream, state) {
         if (!stream.match('""')) return false;
         state.tokenize = tokenTripleString;


### PR DESCRIPTION
<img width="509" alt="screen shot 2016-01-19 at 11 33 01" src="https://cloud.githubusercontent.com/assets/213426/12414806/9133022a-bea0-11e5-8c45-4f7244f93140.png">
- [x] workarounds the indentation, but loses coloring of params in multiline mode (still much better than before IMHO)
- [x] do not impact one line closures
- [ ] will make a PR for codemirror too