### PR TITLE
Do not display widget when cell defines vals

### DIFF
--- a/modules/spark/src/main/scala_2.10/spark-last/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-last/notebook/kernel/Repl.scala
@@ -211,7 +211,8 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
         val lastHandler/*: interp.memberHandlers.MemberHandler*/ = request.handlers.last
 
         try {
-          val evalValue = if (lastHandler.definesValue) {
+          val lastStatementReturnsValue = listDefinedTerms(request).exists(_.name.matches("res[0-9]+"))
+          val evalValue = if (lastHandler.definesValue && lastStatementReturnsValue) {
             // This is true for def's with no parameters, not sure that executing/outputting this is desirable
             // CY: So for whatever reason, line.evalValue attemps to call the $eval method
             // on the class...a method that does not exist. Not sure if this is a bug in the

--- a/modules/spark/src/main/scala_2.10/spark-pre1.5/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-pre1.5/notebook/kernel/Repl.scala
@@ -208,7 +208,9 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
         val lastHandler/*: interp.memberHandlers.MemberHandler*/ = request.handlers.last
 
         try {
-          val evalValue = if (lastHandler.definesValue) { // This is true for def's with no parameters, not sure that executing/outputting this is desirable
+          val lastStatementReturnsValue = listDefinedTerms(request).exists(_.name.matches("res[0-9]+"))
+          val evalValue = if (lastHandler.definesValue && lastStatementReturnsValue) {
+            // This is true for def's with no parameters, not sure that executing/outputting this is desirable
             // CY: So for whatever reason, line.evalValue attemps to call the $eval method
             // on the class...a method that does not exist. Not sure if this is a bug in the
             // REPL or some artifact of how we are calling it.

--- a/modules/spark/src/main/scala_2.11/spark-last/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-last/notebook/kernel/Repl.scala
@@ -217,7 +217,9 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
         listDefinedTerms(request).foreach(onNameDefinion)
 
         try {
-          val evalValue = if (lastHandler.definesValue) { // This is true for def's with no parameters, not sure that executing/outputting this is desirable
+          val lastStatementReturnsValue = listDefinedTerms(request).exists(_.name.matches("res[0-9]+"))
+          val evalValue = if (lastHandler.definesValue && lastStatementReturnsValue) {
+            // This is true for def's with no parameters, not sure that executing/outputting this is desirable
             // CY: So for whatever reason, line.evalValue attemps to call the $eval method
             // on the class...a method that does not exist. Not sure if this is a bug in the
             // REPL or some artifact of how we are calling it.

--- a/modules/spark/src/main/scala_2.11/spark-pre1.5/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-pre1.5/notebook/kernel/Repl.scala
@@ -208,7 +208,9 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
         listDefinedTerms(request).foreach(onNameDefinion)
 
         try {
-          val evalValue = if (lastHandler.definesValue) { // This is true for def's with no parameters, not sure that executing/outputting this is desirable
+          val lastStatementReturnsValue = listDefinedTerms(request).exists(_.name.matches("res[0-9]+"))
+          val evalValue = if (lastHandler.definesValue && lastStatementReturnsValue) {
+            // This is true for def's with no parameters, not sure that executing/outputting this is desirable
             // CY: So for whatever reason, line.evalValue attemps to call the $eval method
             // on the class...a method that does not exist. Not sure if this is a bug in the
             // REPL or some artifact of how we are calling it.

--- a/test/repl/ReplTests.scala
+++ b/test/repl/ReplTests.scala
@@ -51,6 +51,26 @@ class ReplTests extends Specification with BeforeAllAfterAll {
     }
   }
 
+  "do not render the last defined variable when cell returns nothing" in {
+    repl.evaluate("val seq = Seq(1, 2, 3)") match {
+      case ( Success(resultWidgets), _ ) =>
+        resultWidgets.size must beEqualTo(0)
+        success
+      case _ =>
+        failure("Expected not to render the last defined variable")
+    }
+  }
+
+  "render the return value of a cell (if one exists)" in {
+    repl.evaluate("Seq(1, 2, 3)") match {
+      case ( Success(resultWidgets), _ ) =>
+        resultWidgets.size must beEqualTo(1)
+        success
+      case _ =>
+        failure("Expected to render the result value")
+    }
+  }
+
   "return object information for code" in {
     var code =
       """


### PR DESCRIPTION
this was against the Spark's principle of lazy RDD/DataFrame.

@andypetrella @meh-ninja 

<img width="945" alt="screen shot 2016-01-19 at 14 56 31" src="https://cloud.githubusercontent.com/assets/213426/12419165/fd19f5fe-bebc-11e5-9cd3-631cd7c8921b.png">
