### PR TITLE
Fix spark job monitor to return correct cell-id

### DIFF
--- a/modules/common/src/main/scala/notebook/front/gadgets/SparkMonitor.scala
+++ b/modules/common/src/main/scala/notebook/front/gadgets/SparkMonitor.scala
@@ -80,6 +80,7 @@ class SparkMonitor(sparkContext:SparkContext, checkInterval:Long = 1000) extends
         stageId <- j.stageIds
       } yield stageId → j).toMap
 
+      val jobGroupsById = jobsByStageId.values.groupBy(_.jobId).mapValues(_.head.jobGroup)
 
       val stageStats: Seq[JobInfo] = (activeStagesList ++ completedStages ++ pendingStages).flatMap { s: StageInfo =>
         val stageDataOption = listener.stageIdToData.get((s.stageId, s.attemptId))
@@ -109,7 +110,7 @@ class SparkMonitor(sparkContext:SparkContext, checkInterval:Long = 1000) extends
         }.toSeq
 
       jobStats.map { j =>
-        val jobGroup = jobsByStageId(j.jobId).jobGroup
+        val jobGroup = jobGroupsById(j.jobId)
         val cellId = JobTracking.toCellId(jobGroup)
         val jobDuration: Option[Long] = j.submissionTime.map(t => j.completionTime.getOrElse(System.currentTimeMillis) - t)
         val jobDurationStr = jobDuration.map { d =>


### PR DESCRIPTION
often progress get assigned to wrong cell (but results/stdout goes to the correct one). have seen many times in `yarn-client` mode (multiple notebooks open). for some reason quite hard to reproduce in local mode.

fixes #509 

@andypetrella @meh-ninja 