### PR TITLE
SH: print output once, print stderr too

### DIFF
--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -324,11 +324,14 @@ class ReplCalculator(
 
         case shRegex(sh) =>
           val ps = "s\"\"\"" + sh.replaceAll("\\s*\\|\\s*", "\" #\\| \"").replaceAll("\\s*&&\\s*", "\" #&& \"") + "\"\"\""
-          (`text/plain`, s"""
-                            |import sys.process._
-                            |$ps.!!
-              """.stripMargin.trim
-            )
+
+          val shCode =
+            s"""|import sys.process._
+                |println($ps.!!(ProcessLogger(out => (), err => println(err))))
+                |()
+                |""".stripMargin.trim
+          log.debug(s"Generated SH code: $shCode")
+          (`text/plain`, shCode)
 
         case sqlRegex(n, sql) =>
           log.debug(s"Received sql code: [$n] $sql")

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -337,12 +337,13 @@ class ReplCalculator(
 
         case shRegex(sh) =>
           val ps = "s\"\"\""+sh.replaceAll("\\s*\\|\\s*", "\" #\\| \"").replaceAll("\\s*&&\\s*", "\" #&& \"")+"\"\"\""
-
-          (`text/plain`, s"""
-             |import sys.process._
-             |$ps.!!
-              """.stripMargin.trim
-          )
+          val shCode =
+            s"""|import sys.process._
+                |println($ps.!!(ProcessLogger(out => (), err => println(err))))
+                |()
+                |""".stripMargin.trim
+          log.debug(s"Generated SH code: $shCode")
+          (`text/plain`, shCode)
 
         case sqlRegex(n, sql) =>
           log.debug(s"Received sql code: [$n] $sql")


### PR DESCRIPTION
- [x] print shell stderr (it was completely lost, being printed to stdout of `ReplCalculator`)
- [x] do not output `resXX` as it was duplicating the stdout.
- [ ] it would be nice to print `stderr` as error output, but this would need larger refactoring (maybe later)

<img width="467" alt="screen shot 2016-01-21 at 10 49 55" src="https://cloud.githubusercontent.com/assets/213426/12475613/c25dbfa6-c02c-11e5-84e0-6ed4a27871f0.png">

@andypetrella @meh-ninja 
