### PR TITLE
Start the kernel in a read only mode with execution capabilities

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,7 @@ GET            /api/kernelspecs                          controllers.Application
 DELETE         /api/sessions/:kernelId                   controllers.Application.terminateKernel(kernelId:String)
 POST           /api/sessions                             controllers.Application.createSession()
 GET            /api/sessions                             controllers.Application.sessions()
+GET            /api/sessions/path/*path                  controllers.Application.getSession(path:String)
 
 POST           /api/kernels/:kernelId/interrupt          controllers.Application.terminateKernel(kernelId:String)
 POST           /api/kernels/:kernelId/restart            controllers.Application.restartKernel(kernelId:String)

--- a/public/ipython/services/kernels/kernel.js
+++ b/public/ipython/services/kernels/kernel.js
@@ -24,8 +24,10 @@ define([
      * @param {Notebook} notebook - notebook object
      * @param {string} name - the kernel type (e.g. python3)
      */
-    var Kernel = function (kernel_service_url, base_url, ws_url, notebook, name) {
+    var Kernel = function (kernel_service_url, base_url, ws_url, notebook, name, read_only) {
         this.notebook = notebook;
+
+        this.read_only = read_only;
 
         this.events = notebook.events;
 
@@ -717,6 +719,8 @@ define([
          * arugment.  Payload handlers will be passed the corresponding
          * payload and the execute_reply message.
          */
+        if (this.read_only) return;
+
         var content = {
             code: code,
             silent: true,


### PR DESCRIPTION
The kernel control the channels to the backend server, hence it is required to see the evolution of the charts.

However, it wasn't started in read only mode, which was making the notebooks static, but too much.

Now, the kernel is stared but in read only mode, so that, the session controls what can be done (reject all execution and save actions).

Now, we can have active and passive notebooks

PS: this is helpful for demos, training and other things

/cc @vidma @meh-ninja 