### PR TITLE
download and unzip planes data for user

### DIFF
--- a/notebooks/mllib/Planes.snb
+++ b/notebooks/mllib/Planes.snb
@@ -59,7 +59,43 @@
   }, {
     "metadata" : { },
     "cell_type" : "markdown",
-    "source" : "For this small example, we're going to use a subset of the data, that is, only the year [2008](http://stat-computing.org/dataexpo/2009/2008.csv.bz2).\n\n**Warning**: this data is distributed in bz2.\n\nData can be found [here](http://stat-computing.org/dataexpo/2009/the-data.html)"
+    "source" : "For this small example, we're going to use a subset of the data, that is, only the year [2008](http://stat-computing.org/dataexpo/2009/2008.csv.bz2). Data for all available years can be found [here](http://stat-computing.org/dataexpo/2009/the-data.html).\n\n**Warning**: this data is distributed in bz2."
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
+    "source" : "Create directory for our data to live in."
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : false
+    },
+    "cell_type" : "code",
+    "source" : ":sh mkdir -p /home/noootsab/data/dataexpo_2009",
+    "outputs" : [ ]
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
+    "source" : "Download compressed data file."
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : false
+    },
+    "cell_type" : "code",
+    "source" : ":sh wget -O /home/noootsab/data/dataexpo_2009/2008.csv.bz2 http://stat-computing.org/dataexpo/2009/2008.csv.bz2",
+    "outputs" : [ ]
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
+    "source" : "Unzip bz2 file to CSV."
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : false
+    },
+    "cell_type" : "code",
+    "source" : ":sh bunzip2 /home/noootsab/data/dataexpo_2009/2008.csv.bz2",
+    "outputs" : [ ]
   }, {
     "metadata" : { },
     "cell_type" : "markdown",


### PR DESCRIPTION
Loading the [planes data] (http://stat-computing.org/dataexpo/2009/the-data.html) is currently an inconvenient, manual step.

An easier way would be to download/unzip the sample data via Spark Notebook cells.

**I have tested against the following docker image and everything is working fine:**
* *andypetrella/spark-notebook:0.6.2-scala-2.10.4-spark-1.5.2-hadoop-2.6.0*