### PR TITLE
PR for #563 - strings with Windows paths need embedded "\" escaped properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ There is another dependency which is tricky to update, the **jets3t** one.
 
 To update that, you can pass those version as properties, here is an example with the current default ones:
 ```
-sbt -D"spark.version"="1.5.0" -D"hadoop.version"="2.6.0" -D"jets3t.version"="0.7.1" -Dmesos.version="0.24.0" -Dspark.version="2.11.7"
+sbt -D"spark.version"="1.5.0" -D"hadoop.version"="2.6.0" -D"jets3t.version"="0.7.1" -Dmesos.version="0.24.0"
 ```
 
 ##### Create your distribution
@@ -317,7 +317,7 @@ sbt -Dmesos.version=0.23.0 docker:publishLocal
 ```
 
 ##### Customizing your build
-If you want to change some build information like the `name` or the `organization` or even specific to `docker` for your builds.
+If you want to change some build information like the `name` or the `organization` or even specific to `docker` for your builds. 
 Prefeably you would want to avoid having to change the source code of this project.
 
 You can do this by creating some hidden files being caught by the builder but kept out of git (added to `.gitignore`).
@@ -340,7 +340,7 @@ Check `project/MainProperties.scala` for details.
 ###### Update Docker configuration
 Sometimes you may want to change the Docker image which is the result of the `sbt ... docker:publishLocal` command.
 
-Create a file called `.docker.build.conf` next to `build.sbt`, this file is added to `.gitignore`.
+Create a file called `.docker.build.conf` next to `build.sbt`, this file is added to `.gitignore`.  
 The structure of the file is the following:
 ```
 docker {
@@ -686,7 +686,7 @@ Locate the commented key `override` and paste:
     }
 ```
 
-> _Note_:
+> _Note_: 
 > The spark assembly is referred locally in `spark.yarn.jar`, you can also put it `HDFS` yourself and refer its path on hdfs.
 
 
@@ -708,7 +708,7 @@ source /usr/lib/spark/conf/spark-env.sh
 ```
 
 
-> **NOTE**:
+> **NOTE**: 
 > it's better to run the notebook in a `screen` for instance, so that the shell is released and you can quit your ssh connection.
 > ```
 > screen  -m -d -S "snb" bash -c "export SPARK_LOCAL_IP=$(ec2-metadata -o | cut -d ' ' -f2) && export SPARK_LOCAL_HOSTNAME=$(ec2-metadata -h | cut -d ' ' -f2) && export CLASSPATH_OVERRIDES=/usr/lib/hadoop-lzo/lib/hadoop-lzo.jar:/etc/hive/conf:/etc/hadoop/conf:/usr/lib/hadoop/*:/usr/lib/hadoop-hdfs/*:/usr/lib/hadoop-yarn/*:/usr/lib/hadoop-lzo/lib/*:/usr/share/aws/aws-java-sdk/*:/usr/share/aws/emr/emrfs/conf:/usr/share/aws/emr/emrfs/lib/*:/usr/share/aws/emr/emrfs/auxlib/* && source /usr/lib/spark/conf/spark-env.sh && ./bin/spark-notebook -Dconfig.file=./conf/application.conf -Dhttp.port=8989 >> nohup.out"
@@ -722,7 +722,7 @@ There are several manners to access the notebook UI on the port `8989` (see abov
 * sustainable but unsecure: update/create the security group of the master node to open the `8989` port
 * intermediate: use **FoxyProxy** in Chrome (f.i.) to redirect the url to your cluster, after having prealably open a tunnel to the master (*this is described in your cluster summary page*)
 
-> **YARN UI**
+> **YARN UI** 
 >
 > It is available on the port `8088` of your **master**
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ There is another dependency which is tricky to update, the **jets3t** one.
 
 To update that, you can pass those version as properties, here is an example with the current default ones:
 ```
-sbt -D"spark.version"="1.5.0" -D"hadoop.version"="2.6.0" -D"jets3t.version"="0.7.1" -Dmesos.version="0.24.0"
+sbt -D"spark.version"="1.5.0" -D"hadoop.version"="2.6.0" -D"jets3t.version"="0.7.1" -Dmesos.version="0.24.0" -Dspark.version="2.11.7"
 ```
 
 ##### Create your distribution
@@ -317,7 +317,7 @@ sbt -Dmesos.version=0.23.0 docker:publishLocal
 ```
 
 ##### Customizing your build
-If you want to change some build information like the `name` or the `organization` or even specific to `docker` for your builds. 
+If you want to change some build information like the `name` or the `organization` or even specific to `docker` for your builds.
 Prefeably you would want to avoid having to change the source code of this project.
 
 You can do this by creating some hidden files being caught by the builder but kept out of git (added to `.gitignore`).
@@ -340,7 +340,7 @@ Check `project/MainProperties.scala` for details.
 ###### Update Docker configuration
 Sometimes you may want to change the Docker image which is the result of the `sbt ... docker:publishLocal` command.
 
-Create a file called `.docker.build.conf` next to `build.sbt`, this file is added to `.gitignore`.  
+Create a file called `.docker.build.conf` next to `build.sbt`, this file is added to `.gitignore`.
 The structure of the file is the following:
 ```
 docker {
@@ -686,7 +686,7 @@ Locate the commented key `override` and paste:
     }
 ```
 
-> _Note_: 
+> _Note_:
 > The spark assembly is referred locally in `spark.yarn.jar`, you can also put it `HDFS` yourself and refer its path on hdfs.
 
 
@@ -708,7 +708,7 @@ source /usr/lib/spark/conf/spark-env.sh
 ```
 
 
-> **NOTE**: 
+> **NOTE**:
 > it's better to run the notebook in a `screen` for instance, so that the shell is released and you can quit your ssh connection.
 > ```
 > screen  -m -d -S "snb" bash -c "export SPARK_LOCAL_IP=$(ec2-metadata -o | cut -d ' ' -f2) && export SPARK_LOCAL_HOSTNAME=$(ec2-metadata -h | cut -d ' ' -f2) && export CLASSPATH_OVERRIDES=/usr/lib/hadoop-lzo/lib/hadoop-lzo.jar:/etc/hive/conf:/etc/hadoop/conf:/usr/lib/hadoop/*:/usr/lib/hadoop-hdfs/*:/usr/lib/hadoop-yarn/*:/usr/lib/hadoop-lzo/lib/*:/usr/share/aws/aws-java-sdk/*:/usr/share/aws/emr/emrfs/conf:/usr/share/aws/emr/emrfs/lib/*:/usr/share/aws/emr/emrfs/auxlib/* && source /usr/lib/spark/conf/spark-env.sh && ./bin/spark-notebook -Dconfig.file=./conf/application.conf -Dhttp.port=8989 >> nohup.out"
@@ -722,7 +722,7 @@ There are several manners to access the notebook UI on the port `8989` (see abov
 * sustainable but unsecure: update/create the security group of the master node to open the `8989` port
 * intermediate: use **FoxyProxy** in Chrome (f.i.) to redirect the url to your cluster, after having prealably open a tunnel to the master (*this is described in your cluster summary page*)
 
-> **YARN UI** 
+> **YARN UI**
 >
 > It is available on the port `8088` of your **master**
 

--- a/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.10/notebook/ReplCalculator.scala
@@ -441,7 +441,8 @@ class ReplCalculator(
       () => s"""@transient val _5C4L4_N0T3800K_5P4RK_HOOK = "${repl.classServerUri.get}";\n"""
       )
 
-    val nbName = notebookName.replaceAll("\"", "")
+    // Must escape last remaining '\', which could be for windows paths.
+    val nbName = notebookName.replaceAll("\"", "").replace("\\", "\\\\")
 
     val SparkConfScript = {
       val m = customSparkConf .getOrElse(Map.empty[String, String])

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -438,7 +438,8 @@ class ReplCalculator(
     val dummyScript = ("dummy", () => s"""val dummy = ();\n""")
     val SparkHookScript = ("class server", () => s"""@transient val _5C4L4_N0T3800K_5P4RK_HOOK = "${repl.classServerUri.get}";\n""")
 
-    val nbName = notebookName.replaceAll("\"", "")
+    // Must escape last remaining '\', which could be for windows paths.
+    val nbName = notebookName.replaceAll("\"", "").replace("\\", "\\\\")
 
     val SparkConfScript = {
       val m = customSparkConf .getOrElse(Map.empty[String, String])

--- a/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
+++ b/modules/kernel/src/main/scala-2.11/notebook/ReplCalculator.scala
@@ -109,23 +109,10 @@ class ReplCalculator(
     val customDeps = d.mkString("\n")
     val deps = Deps.script(customDeps, remotes, repo).toOption.getOrElse(List.empty[String])
     (deps, ("deps", () => s"""
-                    |val CustomJars = ${ deps.mkString("Array(\"", "\",\"", "\")") }
+                    |val CustomJars = ${ deps.mkString("Array(\"", "\",\"", "\")").replace("\\","\\\\") }
                     |
                     """.stripMargin))
   }.getOrElse((List.empty[String], ("deps", () => "val CustomJars = Array.empty[String]\n")))
-
-
-
-  ("deps", () => customDeps.map { d =>
-    val customDeps = d.mkString("\n")
-
-    val deps = Deps.script(customDeps, remotes, repo).toOption.getOrElse(List.empty[String])
-
-    (deps, s"""
-    |val CustomJars = ${ deps.mkString("Array(\"", "\",\"", "\")") }
-    |
-    """.stripMargin)
-  }.getOrElse((List.empty[String], "val CustomJars = Array.empty[String]\n")))
 
   val ImportsScripts = ("imports", () => customImports.map(_.mkString("\n") + "\n").getOrElse("\n"))
 


### PR DESCRIPTION
Also some minor whitespace changes and a slight change to the `README.md`.