### PR TITLE
Fix lat long validation

### DIFF
--- a/notebooks/mllib/Planes.snb
+++ b/notebooks/mllib/Planes.snb
@@ -59,43 +59,7 @@
   }, {
     "metadata" : { },
     "cell_type" : "markdown",
-    "source" : "For this small example, we're going to use a subset of the data, that is, only the year [2008](http://stat-computing.org/dataexpo/2009/2008.csv.bz2). Data for all available years can be found [here](http://stat-computing.org/dataexpo/2009/the-data.html).\n\n**Warning**: this data is distributed in bz2."
-  }, {
-    "metadata" : { },
-    "cell_type" : "markdown",
-    "source" : "Create directory for our data to live in."
-  }, {
-    "metadata" : {
-      "trusted" : true,
-      "collapsed" : false
-    },
-    "cell_type" : "code",
-    "source" : ":sh mkdir -p /home/noootsab/data/dataexpo_2009",
-    "outputs" : [ ]
-  }, {
-    "metadata" : { },
-    "cell_type" : "markdown",
-    "source" : "Download compressed data file."
-  }, {
-    "metadata" : {
-      "trusted" : true,
-      "collapsed" : false
-    },
-    "cell_type" : "code",
-    "source" : ":sh wget -O /home/noootsab/data/dataexpo_2009/2008.csv.bz2 http://stat-computing.org/dataexpo/2009/2008.csv.bz2",
-    "outputs" : [ ]
-  }, {
-    "metadata" : { },
-    "cell_type" : "markdown",
-    "source" : "Unzip bz2 file to CSV."
-  }, {
-    "metadata" : {
-      "trusted" : true,
-      "collapsed" : false
-    },
-    "cell_type" : "code",
-    "source" : ":sh bunzip2 /home/noootsab/data/dataexpo_2009/2008.csv.bz2",
-    "outputs" : [ ]
+    "source" : "For this small example, we're going to use a subset of the data, that is, only the year [2008](http://stat-computing.org/dataexpo/2009/2008.csv.bz2).\n\n**Warning**: this data is distributed in bz2.\n\nData can be found [here](http://stat-computing.org/dataexpo/2009/the-data.html)"
   }, {
     "metadata" : { },
     "cell_type" : "markdown",

--- a/notebooks/mllib/Planes.snb
+++ b/notebooks/mllib/Planes.snb
@@ -59,7 +59,43 @@
   }, {
     "metadata" : { },
     "cell_type" : "markdown",
-    "source" : "For this small example, we're going to use a subset of the data, that is, only the year [2008](http://stat-computing.org/dataexpo/2009/2008.csv.bz2).\n\n**Warning**: this data is distributed in bz2.\n\nData can be found [here](http://stat-computing.org/dataexpo/2009/the-data.html)"
+    "source" : "For this small example, we're going to use a subset of the data, that is, only the year [2008](http://stat-computing.org/dataexpo/2009/2008.csv.bz2). Data for all available years can be found [here](http://stat-computing.org/dataexpo/2009/the-data.html).\n\n**Warning**: this data is distributed in bz2."
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
+    "source" : "Create directory for our data to live in."
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : false
+    },
+    "cell_type" : "code",
+    "source" : ":sh mkdir -p /home/noootsab/data/dataexpo_2009",
+    "outputs" : [ ]
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
+    "source" : "Download compressed data file."
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : false
+    },
+    "cell_type" : "code",
+    "source" : ":sh wget -O /home/noootsab/data/dataexpo_2009/2008.csv.bz2 http://stat-computing.org/dataexpo/2009/2008.csv.bz2",
+    "outputs" : [ ]
+  }, {
+    "metadata" : { },
+    "cell_type" : "markdown",
+    "source" : "Unzip bz2 file to CSV."
+  }, {
+    "metadata" : {
+      "trusted" : true,
+      "collapsed" : false
+    },
+    "cell_type" : "code",
+    "source" : ":sh bunzip2 /home/noootsab/data/dataexpo_2009/2008.csv.bz2",
+    "outputs" : [ ]
   }, {
     "metadata" : { },
     "cell_type" : "markdown",

--- a/notebooks/streaming/Twitter stream.snb
+++ b/notebooks/streaming/Twitter stream.snb
@@ -179,7 +179,7 @@
       "collapsed" : false
     },
     "cell_type" : "code",
-    "source" : "twitterStream .window(Seconds(60), Seconds(6))  \n              . filter{ s => \n                s.getGeoLocation() != null && \n                s.getGeoLocation().getLatitude() != null && \n                s.getGeoLocation().getLongitude() != null\n              }\n              .map(s => (s.getGeoLocation().getLatitude(), s.getGeoLocation().getLongitude(), s.getText()))\n              .foreachRDD{rdd => \n                geo.applyOn(rdd.take(100))\n              }",
+    "source" : "twitterStream .window(Seconds(60), Seconds(6))  \n              . filter{ s => \n                s.getGeoLocation() != null\n              }\n              .map(s => (s.getGeoLocation().getLatitude(), s.getGeoLocation().getLongitude(), s.getText()))\n              .foreachRDD{rdd => \n                geo.applyOn(rdd.take(100))\n              }",
     "outputs" : [ ]
   }, {
     "metadata" : { },


### PR DESCRIPTION
The following code snippet produces console warnings:
```
twitterStream .window(Seconds(60), Seconds(6))  
              . filter{ s => 
                s.getGeoLocation() != null && 
                s.getGeoLocation().getLatitude() != null && 
                s.getGeoLocation().getLongitude() != null
              }
              .map(s => (s.getGeoLocation().getLatitude(), s.getGeoLocation().getLongitude(), s.getText()))
              .foreachRDD{rdd => 
                geo.applyOn(rdd.take(100))
              }
```
```
<console>:69: warning: comparing values of types Double and Null using `!=' will always yield true
                              s.getGeoLocation().getLatitude() != null && 
                                                               ^
<console>:70: warning: comparing values of types Double and Null using `!=' will always yield true
                              s.getGeoLocation().getLongitude() != null
                                                                ^
```

Since the [twitter4j Geolocation API] (http://twitter4j.org/javadoc/twitter4j/GeoLocation.html#GeoLocation) guarantees that `getLatitude` and `getLongitude` will return `Double` type, can we remove those 2 boolean expressions?