### PR TITLE
Add -feature and -language:reflectiveCalls to compilerArgs in conf/application.conf. Fixed compiler warnings.

### DIFF
--- a/app/notebook/server/CalcWebSocketService.scala
+++ b/app/notebook/server/CalcWebSocketService.scala
@@ -12,6 +12,7 @@ import play.api.libs.json._
 import scala.concurrent._
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
+import scala.language.{postfixOps, reflectiveCalls}
 
 case class SessionOperation(actor: ActorRef, cellId: Option[String])
 

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ publishMavenStyle := false
 
 javacOptions ++= Seq("-Xlint:deprecation", "-g")
 
-scalacOptions += "-deprecation"
+scalacOptions ++= Seq("-deprecation", "-feature")
 
 scalacOptions ++= Seq("-Xmax-classfile-name", "100")
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -139,8 +139,13 @@ manager {
 
     ###
     # REPL compiler options: Use the deprecation warning by default for more
-    # useful feedback about obsolute functions, etc.
-    compilerArgs=[-deprecation]
+    # useful feedback about obsolete functions, etc.
+    # REPL compiler options: Use the -deprecation warning by default for more
+    # useful feedback about obsolete functions, etc. Use the -feature warning
+    # for more explicit warnings about "optional" language features that
+    # should be enabled explicitly. One of those that's used by Spark Notebook
+    # itself is "reflective calls".
+    compilerArgs=["-deprecation", "-feature", "-language:reflectiveCalls"]
   }
 
   clusters {

--- a/modules/common/src/main/post-df/magic.scala
+++ b/modules/common/src/main/post-df/magic.scala
@@ -3,7 +3,6 @@ package notebook.front.widgets.magic
 import org.apache.spark.sql.{DataFrame, Row}
 
 import notebook.front.widgets.magic.Implicits._
-import notebook.front.widgets.magic.LimitBasedSampling
 import notebook.front.widgets.isNumber
 
 trait ExtraSamplerImplicits {

--- a/modules/spark/src/main/scala_2.10/spark-last/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-last/notebook/kernel/Repl.scala
@@ -255,7 +255,7 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
                 }
                 iws(o)
               } catch {
-                case e =>
+                case NonFatal(e) =>
                   e.printStackTrace
                   LOG.error("Ooops, exception in the cell", e)
                   <span style="color:red;">Ooops, exception in the cell: {e.getMessage}</span>
@@ -263,7 +263,7 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
             } else {
               // a line like println(...) is technically a val, but returns null for some reason
               // so wrap it in an option in case that happens...
-              Option(line.call("$result")) map { result => Text(try { result.toString } catch { case e => "Fail to `toString` the result: " + e.getMessage }) } getOrElse NodeSeq.Empty
+              Option(line.call("$result")) map { result => Text(try { result.toString } catch { case NonFatal(e) => "Fail to `toString` the result: " + e.getMessage }) } getOrElse NodeSeq.Empty
             }
           } else {
             NodeSeq.Empty

--- a/modules/spark/src/main/scala_2.10/spark-pre1.5/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.10/spark-pre1.5/notebook/kernel/Repl.scala
@@ -252,7 +252,7 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
                 }
                 iws(o)
               } catch {
-                case e =>
+                case NonFatal(e) =>
                   e.printStackTrace
                   LOG.error("Ooops, exception in the cell", e)
                   <span style="color:red;">Ooops, exception in the cell: {e.getMessage}</span>
@@ -260,7 +260,7 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
             } else {
               // a line like println(...) is technically a val, but returns null for some reason
               // so wrap it in an option in case that happens...
-              Option(line.call("$result")) map { result => Text(try { result.toString } catch { case e => "Fail to `toString` the result: " + e.getMessage }) } getOrElse NodeSeq.Empty
+              Option(line.call("$result")) map { result => Text(try { result.toString } catch { case NonFatal(e) => "Fail to `toString` the result: " + e.getMessage }) } getOrElse NodeSeq.Empty
             }
           } else {
             NodeSeq.Empty

--- a/modules/spark/src/main/scala_2.11/spark-last/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-last/notebook/kernel/Repl.scala
@@ -48,16 +48,16 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
     settings.embeddedDefaults[Repl]
 
     if (!compilerOpts.isEmpty) settings.processArguments(compilerOpts, false)
-    
+
     val conf = new SparkConf()
 
     val tmp = System.getProperty("java.io.tmpdir")
     val rootDir = conf.get("spark.repl.classdir", tmp)
     val outputDir = org.apache.spark.Boot.createTempDir(rootDir, "spark-notebook-repl")
-   
-   
-   
-    
+
+
+
+
     settings.processArguments(List("-Yrepl-class-based", "-Yrepl-outdir", s"${outputDir.getAbsolutePath}", "-Yrepl-sync"), true)
 
     // fix for #52
@@ -101,7 +101,7 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
     //val i = new HackIMain(settings, stdout)
     loop = new org.apache.spark.repl.HackSparkILoop(stdout, outputDir)
 
-    
+
     jars.foreach { jar =>
       import scala.tools.nsc.util.ClassPath
       val f = scala.tools.nsc.io.File(jar).normalize
@@ -244,13 +244,13 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
                 def getModule(c:Class[_]) = c.getDeclaredField(interp.global.nme.MODULE_INSTANCE_FIELD.toString).get(())
 
                 val module = getModule(renderedClass2)
-                
+
                 val topInstance = module.getClass.getDeclaredMethod("$iw").invoke(module)
 
                 def iws(o:Class[_], instance: Any) : NodeSeq = {
                   val tryClass = o.getName+"$$iw"
                   val o2 = Try{module.getClass.getClassLoader.loadClass(tryClass)}.toOption
-                  
+
                   o2 match {
                     case Some(o3) =>
                       val inst = o.getDeclaredMethod("$iw").invoke(instance)
@@ -258,13 +258,13 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
                     case None =>
                       val r = o.getDeclaredMethod("rendered").invoke(instance)
                       val h = r.asInstanceOf[Widget].toHtml
-                      h  
+                      h
                   }
                 }
 
                 iws(module.getClass.getClassLoader.loadClass(renderedClass2.getName + "$iw"), topInstance)
               } catch {
-                case e: Throwable =>
+                case NonFatal(e) =>
                   e.printStackTrace
                   LOG.error("Ooops, exception in the cell", e)
                   <span style="color:red;">Ooops, exception in the cell: {e.getMessage}</span>

--- a/modules/spark/src/main/scala_2.11/spark-pre1.5/notebook/kernel/Repl.scala
+++ b/modules/spark/src/main/scala_2.11/spark-pre1.5/notebook/kernel/Repl.scala
@@ -250,7 +250,7 @@ class Repl(val compilerOpts: List[String], val jars:List[String]=Nil) extends Re
                 }
                 iws(o)
               } catch {
-                case e =>
+                case NonFatal(e) =>
                   e.printStackTrace
                   LOG.error("Ooops, exception in the cell", e)
                   <span style="color:red;">Ooops, exception in the cell: {e.getMessage}</span>


### PR DESCRIPTION
This pull request modified `compilerArgs` in `conf/application.conf`. It adds `-feature`, to explain when optional language features are used without explicitly enabling them, and it adds `-language:reflectiveCalls` to explicitly enable this optional feature, which used by Spark Notebook itself.

Without both compiler flags, almost every cell prints a warning from the compiler about an optional feature being used, but with no useful information except to add `-feature` to get more details. The actual issue is the use reflection by Spark Notebook itself.