### PR TITLE
Remove notebook canonical path constraint #577

### DIFF
--- a/app/notebook/server/NotebookManager.scala
+++ b/app/notebook/server/NotebookManager.scala
@@ -25,10 +25,6 @@ class NotebookManager(val name: String, val notebookDir: File) {
     val basePath = notebookDir.getCanonicalPath
     val decodedPath = URLDecoder.decode(path, UTF_8)
     val nbFile = new File(basePath, decodedPath)
-    //  This check is probably not strictly necessary due to URL encoding of name
-    //  (should escape any path traversal components), but let's be safe
-    require(nbFile.getCanonicalPath.startsWith(basePath),
-      "Unable to access notebook outside of notebooks path.")
     nbFile
   }
 


### PR DESCRIPTION
This PR removes the canonical check on notebooks in order to allow symlinks from other parts of a filesystem as described in issue #577