### PR TITLE
Predictable data series order in pivotchart

### DIFF
--- a/app/assets/javascripts/notebook/magic/pivotChart.coffee
+++ b/app/assets/javascripts/notebook/magic/pivotChart.coffee
@@ -65,6 +65,9 @@ define([
               show: true
             }
           },
+          data: {
+            order: null
+          },
           axis: {
             x: {
               tick: {

--- a/public/javascripts/third/c3_renderers.js
+++ b/public/javascripts/third/c3_renderers.js
@@ -170,7 +170,6 @@
             }
           },
           data: {
-            type: chartOpts.type
           },
           tooltip: {
             grouped: false
@@ -180,6 +179,11 @@
           }
         };
         $.extend(params, opts.c3);
+
+        // allow user to provide custom params for c3.data.someUserOption
+        // overwrite data.type as it is dynamic
+        params.data.type = chartOpts.type;
+
         if (chartOpts.type === "scatter") {
           xs = {};
           numSeries = 0;


### PR DESCRIPTION
order data-series by same predictable order (seems to be alphanumerical). [docs here](http://c3js.org/samples/data_order.html)

<img width="1146" alt="screen shot 2016-03-09 at 10 40 37" src="https://cloud.githubusercontent.com/assets/213426/13631172/7602ff36-e5e3-11e5-8504-0e576eee90c5.png">

@jarutis and other our analysts will be very happy about this ;) If there is a need we could further improve this, e.g. make this order configurable from code cells.
cc @andypetrella @meh-ninja 

- [x] fix C3 renderers
- [x] make PR for pivottable's `c3_renderers.js`
