### PR TITLE
fix widgets to work with empty datasets

### DIFF
--- a/modules/common/src/main/post-df/magic.scala
+++ b/modules/common/src/main/post-df/magic.scala
@@ -39,6 +39,7 @@ trait ExtraMagicImplicits {
         encoded
       } else Nil
     }
+    override def headers(df: DataFrame)(implicit sampler:Sampler[DataFrame]) = df.columns
     def count(x:DataFrame) = x.count()
     def append(x:DataFrame, y:DataFrame) = x unionAll y
     def mkString(x:DataFrame, sep:String=""):String = x.rdd.toDebugString

--- a/modules/common/src/main/post-df/magic.scala
+++ b/modules/common/src/main/post-df/magic.scala
@@ -31,11 +31,7 @@ trait ExtraMagicImplicits {
     def apply(df:DataFrame, max:Int)(implicit sampler:Sampler[DataFrame]):Seq[MagicRenderPoint] = {
       val rows = sampler(df, max).collect
       if (rows.length > 0) {
-        val points = df.schema.toList.map(_.dataType) match {
-          case List(x) if x.isInstanceOf[org.apache.spark.sql.types.StringType] => rows.map(i => StringPoint(i.asInstanceOf[String]))
-          case _                                                                => rows.map(i => DFPoint(i, df))
-        }
-
+        val points = rows.map(i => DFPoint(i, df))
         val encoded = points.zipWithIndex.map { case (point, index) => point.values match {
           case Seq(o)    if isNumber(o)   =>  AnyPoint((index, o))
           case _                          =>  point

--- a/modules/common/src/main/scala/notebook/front/widgets/Magic.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/Magic.scala
@@ -102,6 +102,17 @@ object Implicits extends ExtraMagicImplicits {
 
   trait ToPoints[C] {
     def apply(c:C, max:Int)(implicit sampler:Sampler[C]):Seq[MagicRenderPoint]
+
+    /**
+      * Dummy implementation which tries to get the fetch schema/headers from the first element
+      * to be overriden by specific converters.
+      */
+    def headers(x: C)(implicit sampler:Sampler[C]) = {
+      apply(x, max = 1)
+        .headOption
+        .map(_.headers)
+        .getOrElse(Seq("can not display empty seq"))
+    }
     def count(x:C):Long
     def append(x:C, y:C):C
     def mkString(x:C, sep:String=""):String
@@ -109,7 +120,7 @@ object Implicits extends ExtraMagicImplicits {
 
   implicit def SeqToPoints[T] = new ToPoints[Seq[T]] {
     def apply(_x:Seq[T], max:Int)(implicit sampler:Sampler[Seq[T]]):Seq[MagicRenderPoint] =
-      if (!_x.isEmpty) {
+      if (_x.nonEmpty) {
         val x = sampler(_x, max)
         val points:Seq[MagicRenderPoint] = x.head match {
           case _:Row   => x.map(i => SqlRowPoint(i.asInstanceOf[Row]))


### PR DESCRIPTION
partially fixes issue https://github.com/andypetrella/spark-notebook/issues/604

@andypetrella 

empty seq:
<img width="1057" alt="screen shot 2016-03-09 at 15 28 29" src="https://cloud.githubusercontent.com/assets/213426/13638305/f5f0c5d4-e60b-11e5-9ea9-a5e69e54165e.png">

dataframe:
<img width="1074" alt="screen shot 2016-03-09 at 15 28 42" src="https://cloud.githubusercontent.com/assets/213426/13638306/f776d65a-e60b-11e5-9273-e19a8d6c69f4.png">
<img width="692" alt="screen shot 2016-03-09 at 15 28 53" src="https://cloud.githubusercontent.com/assets/213426/13638307/f857d808-e60b-11e5-8985-cad7b70cd0ca.png">
