### PR TITLE
Fix DownloadCSV in scala 2.11

### DIFF
--- a/modules/common/src/main/post-df/DownloadCsv.scala
+++ b/modules/common/src/main/post-df/DownloadCsv.scala
@@ -1,6 +1,6 @@
 package notebook.front.widgets
 
-import notebook.front._
+import notebook.front.Widget
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.DataFrame
@@ -8,8 +8,9 @@ import org.apache.spark.sql.DataFrame
 case class DownloadCsv(df: DataFrame, webHdfsUserName: String = "hive") extends Widget {
   val log = org.slf4j.LoggerFactory.getLogger("SparkInfo")
 
+  val link = SpreadsheetOutput.downloadCsv(df, webHdfsUserName = webHdfsUserName)
+
   lazy val toHtml = {
-    val link = SpreadsheetOutput.downloadCsv(df, webHdfsUserName = webHdfsUserName)
     <div class="download-csv">
       <a target="_blank" href={link}>Download here</a>
     </div>


### PR DESCRIPTION
in 2.11 was giving a horrible stracktrace:
```
kernel.js:975 Server log> [Tue Mar 22 2016 09:59:57 GMT+0200 (EET)] [notebook.kernel.Repl] Ooops, exception in the cell. Stacktrace:
java.util.ServiceConfigurationError: org.apache.spark.sql.sources.DataSourceRegister: Provider org.apache.spark.sql.execution.datasources.jdbc.DefaultSource not a subtype
	at java.util.ServiceLoader.fail(ServiceLoader.java:231)
	at java.util.ServiceLoader.access$300(ServiceLoader.java:181)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:369)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:445)
	at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:43)
	at scala.collection.Iterator$class.foreach(Iterator.scala:742)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1194)
	at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	at scala.collection.TraversableLike$class.filterImpl(TraversableLike.scala:258)
	at scala.collection.TraversableLike$class.filter(TraversableLike.scala:270)
	at scala.collection.AbstractTraversable.filter(Traversable.scala:104)
	at org.apache.spark.sql.execution.datasources.ResolvedDataSource$.lookupDataSource(ResolvedDataSource.scala:59)
	at org.apache.spark.sql.execution.datasources.ResolvedDataSource$.apply(ResolvedDataSource.scala:219)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:148)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:139)
	at notebook.front.widgets.SpreadsheetOutput$.saveAsCsv(DownloadCsv.scala:45)
	at notebook.front.widgets.SpreadsheetOutput$.downloadCsv(DownloadCsv.scala:70)
	at notebook.front.widgets.DownloadCsv.toHtml$lzycompute(DownloadCsv.scala:12)
	at notebook.front.widgets.DownloadCsv.toHtml(DownloadCsv.scala:11)
	at notebook.front.widgets.DownloadCsv.toHtml(DownloadCsv.scala:8)
	at notebook.kernel.Repl.iws$1(Repl.scala:260)
	at notebook.kernel.Repl.liftedTree1$1(Repl.scala:265)
	at notebook.kernel.Repl.evaluate(Repl.scala:240)
	at notebook.client.ReplCalculator$$anonfun$13$$anon$1$$anonfun$30.replEvaluate$1(ReplCalculator.scala:401)
	at notebook.client.ReplCalculator$$anonfun$13$$anon$1$$anonfun$30.apply(ReplCalculator.scala:414)
	at notebook.client.ReplCalculator$$anonfun$13$$anon$1$$anonfun$30.apply(ReplCalculator.scala:395)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:397)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

cc @andypetrella