### PR TITLE
Hide sidebar by default and move link to Spark UI to the menu

### DIFF
--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -134,6 +134,9 @@
                         <li id="toggle-sidebar-menu-item">
                             <a href="#" id="toggle-sidebar">Toggle sidebar</a>
                         </li>
+                        <li id="link-to-spark-ui" class="disabled">
+                            <a href="#" target="_blank">Open Spark UI</a>
+                        </li>
                         <li class="divider"></li>
                         <li id="read_only_view">
                             <a href="?read_only=1" target="_blank">
@@ -338,7 +341,7 @@
             <div id="sidebar" class="gridster hidden">
                 <ul>
                     <li class="widget" data-row="1" data-col="1" data-sizex="2" data-sizey="1">
-                        <h4 id="spark-jobs">Spark Job Progress&nbsp;&nbsp;<span id="spark-ui-link-container"></span></h4>
+                        <h4 id="spark-jobs">Spark Job Progress</h4>
                         <div id="all-jobs-progress-bar"></div>
                     </li>
 

--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -132,7 +132,7 @@
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>
                     <ul id="view_menu" class="dropdown-menu">
                         <li id="toggle-sidebar-menu-item">
-                            <a href="#" id="toggle-sidebar">Hide/unhide sidebar</a>
+                            <a href="#" id="toggle-sidebar">Toggle sidebar</a>
                         </li>
                         <li class="divider"></li>
                         <li id="read_only_view">
@@ -332,10 +332,10 @@
 } {
   <div id="ipython-main-app">
       <div id="notebook_panel" class="container-fluid">
-          <div id="notebook" class="col-md-9"></div>
+          <div id="notebook" class="col-md-12"></div>
 
           <div id="notebook-panels" class="col-md-3" >
-            <div id="sidebar" class="gridster">
+            <div id="sidebar" class="gridster hidden">
                 <ul>
                     <li class="widget" data-row="1" data-col="1" data-sizex="2" data-sizey="1">
                         <h4 id="spark-jobs">Spark Job Progress&nbsp;&nbsp;<span id="spark-ui-link-container"></span></h4>

--- a/public/javascripts/notebook/job_progress.js
+++ b/public/javascripts/notebook/job_progress.js
@@ -10,10 +10,9 @@ define([
     require(['observable'], function(O) {
       var progress = O.makeObservableArray("jobsProgress");
 
-      var updateSparkUiLink = function(sparkUi){
-        if (sparkUi != "") {
-          var sparkUiLink = $("<a href='" + sparkUi + "' id='spark-ui-link' target='_blank'>open SparkUI</a>")
-          $("#spark-ui-link-container").html(sparkUiLink);
+      var updateSparkUiLink = function(sparkUiUrl) {
+        if (sparkUiUrl != "") {
+          $('#link-to-spark-ui').removeClass('disabled').find('a').attr('href', sparkUiUrl);
         }
       };
 

--- a/public/javascripts/notebook/sidebar.js
+++ b/public/javascripts/notebook/sidebar.js
@@ -134,7 +134,7 @@ require(["jquery", "underscore", "base/js/events", "knockout"], function($, _, e
       });
     });
 
-    // hide/unhide sidebar
+    // toggle sidebar
     $('a#toggle-sidebar').click(function(){
       $('#sidebar').toggleClass('hidden');
       // expand the notebook when sidebar is hidden

--- a/public/javascripts/notebook/sidebar.js
+++ b/public/javascripts/notebook/sidebar.js
@@ -118,8 +118,10 @@ require(["jquery", "underscore", "base/js/events", "knockout"], function($, _, e
       // clear sidebar on kernel restart
       // reset term definitions
       model.clearDefinitions();
-      // clear old progressbar & link to spark UI
-      $('#spark-ui-link-container, #all-jobs-progress-bar').html('');
+      // clear old progressbar
+      $('#all-jobs-progress-bar').html('');
+      // disable link to Spark UI
+      $('#link-to-spark-ui').addClass('disabled').find('a').attr('href', '#');
     });
 
     events.on('kernel_ready.Kernel', function(e, c) {


### PR DESCRIPTION
Hey @andypetrella,

we haven't found much use of the sidebar which doesn't seem to be finished yet (the style was odd for a while, chat seems to be in a very early/experimental phase, list of terms isn't that useful (especially with ever-growing list of `resN` variables..)) and thus we're constantly hiding it. Obviously, this constant hiding is very irritating and such unfinished part of the product increases learning curve for newbies, we've decided to simply hide it by default. What do you think?

We could also use browser cookies to remember last sidebar visibility choice (i.e. people who do like the sidebar could have it always open, otherwise it would be always hidden), but this requires to pick some library to manage cookies :) if you like this idea, please tell me what's your policy with new JS dependencies?

Here's how it looks after the change:

![image](https://cloud.githubusercontent.com/assets/35432/14105121/3b270cc0-f5b2-11e5-8e36-29486cc6311f.png)

![image](https://cloud.githubusercontent.com/assets/35432/14105118/2b063488-f5b2-11e5-8c5e-b48ec24745e8.png)

cc @vidma 