### PR TITLE
Replace most dimple w/ C3 - Add TimeseriesChart

### DIFF
--- a/app/assets/javascripts/notebook/magic/barChart.coffee
+++ b/app/assets/javascripts/notebook/magic/barChart.coffee
@@ -2,31 +2,66 @@ define([
     'observable'
     'knockout'
     'd3'
-    'dimple'
-], (Observable, ko, d3, dimple) ->
+    'c3'
+], (Observable, ko, d3, c3) ->
   (dataO, container, options) ->
     w = options.width||600
     h = options.height||400
 
-    svg = d3.select(container).append("svg:svg").attr("width", w+"px").attr("height", h+"px").attr("id", "bar"+@genId)
-    chart = new dimple.chart(svg, @dataInit)
-    chart.setBounds(w*(50/600), h*(20/400), w *(540/600), h*(350/400))
+    chart_container = $("<div>").addClass("custom-c3-chart").attr("width", w+"px").attr("height", h+"px")
+    chart_container.attr("id", "custom-c3-chart-"+@genId).appendTo(container)
 
-    #<painful> → https://github.com/PMSI-AlignAlytics/dimple/issues/140
-    order = []
-    n = @dataInit.length-1
-    for i in [0..n]
-      order.push(@dataInit[i][options.x]) if (order.indexOf(@dataInit[i][options.x]) == -1)
-    x = chart.addCategoryAxis("x", options.x)
-    x.addOrderRule(order)
-    #</painful>
+    data = {
+      type: "bar"
+    }
 
-    chart.addMeasureAxis("y", options.y)
-    chart.addSeries(null, dimple.plot.bar)
-    chart.draw()
+    prepareData = (data, ds) ->
+      if options.g
+        groups = _.unique(ds.map((d) -> d[options.g]))
+        xs = {}
+        cols = {}
+        groups.forEach((g) =>
+          xs[""+g] = ""+g+"_x"
+          cols[""+g] = []
+          cols[""+g+"_x"] = []
+        )
+        ds.forEach((d) =>
+          cols[d[options.g]+"_x"].push(d[options.x])
+          cols[d[options.g]].push(d[options.y])
+        )
+        data.columns = []
+        _.each(cols, (c, k) =>
+          c.unshift(k)
+          data.columns.push(c)
+        )
+        data.xs = xs
+      else
+        xs = {}
+        xs[options.x] = options.x
+        data.x = options.x
+        dataI = _.map(ds, (d) -> [d._1, d._2])
+        dataI.unshift([options.x, options.y])
+        data.rows = dataI
+      data
+
+    chart = c3.generate(
+      bindto: "#" + chart_container.attr("id"),
+      data: prepareData(data, @dataInit),
+      axis: {
+        x: {
+          label: options.x,
+          tick: {
+              fit: false
+          }
+        },
+        y: {
+          label: options.y
+        }
+      }
+    )
 
     dataO.subscribe( (newData) =>
-      chart.data = newData
-      chart.draw(1000)
+      #chart.unload();
+      chart.load(prepareData(data, newData));
     )
 )

--- a/app/assets/javascripts/notebook/magic/scatterChart.coffee
+++ b/app/assets/javascripts/notebook/magic/scatterChart.coffee
@@ -2,31 +2,66 @@ define([
     'observable'
     'knockout'
     'd3'
-    'dimple'
-], (Observable, ko, d3, dimple) ->
+    'c3'
+], (Observable, ko, d3, c3) ->
   (dataO, container, options) ->
     w = options.width||600
     h = options.height||400
 
-    svg = d3.select(container).append("svg:svg").attr("width", w+"px").attr("height", h+"px").attr("id", "scatter"+@genId)
-    chart = new dimple.chart(svg, @dataInit)
-    chart.setBounds(w*(50/600), h*(20/400), w *(540/600), h*(350/400))
+    chart_container = $("<div>").addClass("custom-c3-chart").attr("width", w+"px").attr("height", h+"px")
+    chart_container.attr("id", "custom-c3-chart-"+@genId).appendTo(container)
 
-    #<painful> → https://github.com/PMSI-AlignAlytics/dimple/issues/140
-    order = []
-    n = @dataInit.length-1
-    for i in [0..n]
-      order.push(@dataInit[i][options.x]) if (order.indexOf(@dataInit[i][options.x]) == -1)
-    x = chart.addCategoryAxis("x", options.x)
-    x.addOrderRule(order)
-    #</painful>
-    y = chart.addMeasureAxis("y", options.y)
+    data = {
+      type: "scatter"
+    }
 
-    chart.addSeries([options.y], dimple.plot.bubble)
-    chart.draw()
+    prepareData = (data, ds) ->
+      if options.g
+        groups = _.unique(ds.map((d) -> d[options.g]))
+        xs = {}
+        cols = {}
+        groups.forEach((g) =>
+          xs[""+g] = ""+g+"_x"
+          cols[""+g] = []
+          cols[""+g+"_x"] = []
+        )
+        ds.forEach((d) =>
+          cols[d[options.g]+"_x"].push(d[options.x])
+          cols[d[options.g]].push(d[options.y])
+        )
+        data.columns = []
+        _.each(cols, (c, k) =>
+          c.unshift(k)
+          data.columns.push(c)
+        )
+        data.xs = xs
+      else
+        xs = {}
+        xs[options.x] = options.x
+        data.x = options.x
+        dataI = _.map(ds, (d) -> [d._1, d._2])
+        dataI.unshift([options.x, options.y])
+        data.rows = dataI
+      data
+
+    chart = c3.generate(
+      bindto: "#" + chart_container.attr("id"),
+      data: prepareData(data, @dataInit),
+      axis: {
+        x: {
+          label: options.x,
+          tick: {
+              fit: false
+          }
+        },
+        y: {
+          label: options.y
+        }
+      }
+    )
 
     dataO.subscribe( (newData) =>
-      chart.data = newData
-      chart.draw(1000)
+      #chart.unload();
+      chart.load(prepareData(data, newData));
     )
 )

--- a/app/assets/javascripts/notebook/magic/tsChart.coffee
+++ b/app/assets/javascripts/notebook/magic/tsChart.coffee
@@ -12,7 +12,6 @@ define([
     chart_container.attr("id", "custom-c3-chart-"+@genId).appendTo(container)
 
     data = {
-      type: "line"
     }
 
     prepareData = (data, ds) ->
@@ -49,9 +48,9 @@ define([
       data: prepareData(data, @dataInit),
       axis: {
         x: {
-          label: options.x,
+          type: 'timeseries',
           tick: {
-              fit: false
+            format: options.tickFormat
           }
         },
         y: {

--- a/modules/common/src/main/scala/notebook/front/widgets/Magic.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/Magic.scala
@@ -4,6 +4,9 @@ import notebook.util.Reflector
 import notebook.front.widgets.isNumber
 import org.apache.spark.sql.{Row}
 
+import java.util.Date
+import java.sql.{Date => SqlDate}
+
 import com.vividsolutions.jts.geom.Geometry
 import org.wololo.geojson.GeoJSON
 
@@ -33,6 +36,8 @@ case class AnyPoint(any:Any, header:Option[String]=None) extends MagicRenderPoin
       case v: BigDecimal  => Seq(header.getOrElse("BigDecimal"))
       case v: String      => Seq(header.getOrElse("String"))
       case v: Boolean     => Seq(header.getOrElse("Boolean"))
+      case v: Date        => Seq(header.getOrElse("Date"))
+      case v: SqlDate     => Seq(header.getOrElse("Date"))
       case v: Geometry    => Seq(header.getOrElse("Geometry"))
       case v: GeoJSON     => Seq(header.getOrElse("GeoJSON"))
       case v: Any         => Reflector.toFieldNameArray(any)
@@ -44,6 +49,8 @@ case class AnyPoint(any:Any, header:Option[String]=None) extends MagicRenderPoin
       case v: Double      => Seq(v)
       case v: Long        => Seq(v)
       case v: BigDecimal  => Seq(v)
+      case v: Date        => Seq(v.getTime)
+      case v: SqlDate     => Seq(v.getTime)
       case v: String      => Seq(v)
       case v: Boolean     => Seq(v)
       case v: Geometry    => Seq(v)

--- a/modules/common/src/main/scala/notebook/front/widgets/Utils.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/Utils.scala
@@ -11,6 +11,7 @@ import notebook.front.widgets.magic.SamplerImplicits._
 
 import notebook.util.Reflector
 import java.util.Date
+import java.sql.{Date=>SqlDate}
 
 import com.vividsolutions.jts.geom.Geometry
 import org.wololo.geojson.GeoJSON
@@ -43,26 +44,28 @@ trait Utils {
 
   def toJson(obj: Any): JsValue = {
     obj match {
-      case null => JsNull
-      case v: Int => JsNumber(v)
-      case v: Float => JsNumber(v)
-      case v: Double => JsNumber(v)
-      case v: Long => JsNumber(v)
-      case v: BigDecimal => JsNumber(v)
-      case v: String => JsString(v)
-      case v: Boolean => JsBoolean(v)
-      case v: Geometry =>
+      case null             => JsNull
+      case v: Int           => JsNumber(v)
+      case v: Float         => JsNumber(v)
+      case v: Double        => JsNumber(v)
+      case v: Long          => JsNumber(v)
+      case v: BigDecimal    => JsNumber(v)
+      case v: String        => JsString(v)
+      case v: Boolean       => JsBoolean(v)
+      case v: Date          => JsNumber(v.getTime)
+      case v: SqlDate       => JsNumber(v.getTime)
+      case v: Geometry      =>
         val json  = geometryToGeoJSON(v)
         val jsonstring = json.toString()
         Json.parse(jsonstring)
-      case v: GeoJSON =>
+      case v: GeoJSON       =>
         Json.parse(v.toString())
-      case v: Iterable[_] =>
+      case v: Iterable[_]   =>
         val it = v.map(x => toJson(x))
         JsArray(it.toSeq)
-      case v:Tuple2[_,_] =>
+      case v:Tuple2[_,_]    =>
         JsObject(Seq(("_1" → toJson(v._1)), ("_2" → toJson(v._2))))
-      case v:Tuple3[_,_,_] =>
+      case v:Tuple3[_,_,_]  =>
         JsObject(Seq(("_1" → toJson(v._1)), ("_2" → toJson(v._2)), ("_3" → toJson(v._3))))
       case v =>
         JsString(v.toString)
@@ -70,7 +73,7 @@ trait Utils {
   }
 
   def isNumber(obj: Any) = obj.isInstanceOf[Int] || obj.isInstanceOf[Float] || obj.isInstanceOf[Double] || obj.isInstanceOf[Long]
-  def isDate(obj: Any) = obj.isInstanceOf[Date]
+  def isDate(obj: Any) = obj.isInstanceOf[Date] || obj.isInstanceOf[SqlDate]
 
   def parseGeoJSON(s:String):GeoJSON = org.wololo.geojson.GeoJSONFactory.create(s)
   def geometryToGeoJSON(g:Geometry):GeoJSON = {

--- a/modules/common/src/main/scala/notebook/front/widgets/charts/Defaults.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/charts/Defaults.scala
@@ -58,25 +58,61 @@ case class Tabs[C:ToPoints:Sampler](originalData:C, pages:Seq[(String, Chart[C])
   }
 }
 
-case class ScatterChart[C:ToPoints:Sampler](originalData:C, fields:Option[(String, String)]=None, override val sizes:(Int, Int)=(600, 400), maxPoints:Int = DEFAULT_MAX_POINTS) extends Chart[C](originalData, maxPoints) with Sequencifiable[C] {
+case class ScatterChart[C:ToPoints:Sampler](
+    originalData:C,
+    fields:Option[(String, String)]=None,
+    override val sizes:(Int, Int)=(600, 400),
+    maxPoints:Int = DEFAULT_MAX_POINTS,
+    groupField: Option[String]=None
+  ) extends Chart[C](originalData, maxPoints) with Sequencifiable[C] {
 
-  override val scripts = List(Script( "magic/scatterChart",
-                                      Json.obj( "x" → f1, "y" → f2,
-                                                "width" → sizes._1, "height" → sizes._2)))
+  val o = Json.obj( "x" → f1, "y" → f2, "width" → sizes._1, "height" → sizes._2) ++
+            groupField.map(g => Json.obj("g" → g)).getOrElse(Json.obj())
+
+  override val scripts = List(Script( "magic/scatterChart", o))
 }
 
-case class LineChart[C:ToPoints:Sampler](originalData:C, fields:Option[(String, String)]=None, override val sizes:(Int, Int)=(600, 400), maxPoints:Int = DEFAULT_MAX_POINTS) extends Chart[C](originalData, maxPoints) with Sequencifiable[C] {
+case class LineChart[C:ToPoints:Sampler](
+    originalData:C,
+    fields:Option[(String, String)]=None,
+    override val sizes:(Int, Int)=(600, 400),
+    maxPoints:Int = DEFAULT_MAX_POINTS,
+    groupField: Option[String]=None
+  ) extends Chart[C](originalData, maxPoints) with Sequencifiable[C] {
 
-  override val scripts = List(Script( "magic/lineChart",
-                                      Json.obj( "x" → f1, "y" → f2,
-                                                "width" → sizes._1, "height" → sizes._2)))
+  val o = Json.obj( "x" → f1, "y" → f2, "width" → sizes._1, "height" → sizes._2) ++
+            groupField.map(g => Json.obj("g" → g)).getOrElse(Json.obj())
+
+  override val scripts = List(Script( "magic/lineChart", o))
 }
 
-case class BarChart[C:ToPoints:Sampler](originalData:C, fields:Option[(String, String)]=None, override val sizes:(Int, Int)=(600, 400), maxPoints:Int = DEFAULT_MAX_POINTS) extends Chart[C](originalData, maxPoints) with Sequencifiable[C] {
+case class TimeseriesChart[C:ToPoints:Sampler](
+    originalData:C,
+    fields:Option[(String, String)]=None,
+    override val sizes:(Int, Int)=(600, 400),
+    maxPoints:Int = DEFAULT_MAX_POINTS,
+    groupField: Option[String]=None,
+    tickFormat:String = "%Y-%m-%d %H:%M:%S"
+  ) extends Chart[C](originalData, maxPoints) with Sequencifiable[C] {
 
-  override val scripts = List(Script( "magic/barChart",
-                                      Json.obj( "x" → f1, "y" → f2,
-                                                "width" → sizes._1, "height" → sizes._2)))
+  val o = Json.obj( "x" → f1, "y" → f2, "width" → sizes._1, "height" → sizes._2, "tickFormat" → tickFormat) ++
+            groupField.map(g => Json.obj("g" → g)).getOrElse(Json.obj())
+
+  override val scripts = List(Script( "magic/tsChart", o))
+}
+
+case class BarChart[C:ToPoints:Sampler](
+    originalData:C,
+    fields:Option[(String, String)]=None,
+    override val sizes:(Int, Int)=(600, 400),
+    maxPoints:Int = DEFAULT_MAX_POINTS,
+    groupField: Option[String]=None
+  ) extends Chart[C](originalData, maxPoints) with Sequencifiable[C] {
+
+  val o = Json.obj( "x" → f1, "y" → f2, "width" → sizes._1, "height" → sizes._2) ++
+            groupField.map(g => Json.obj("g" → g)).getOrElse(Json.obj())
+
+  override val scripts = List(Script( "magic/barChart", o))
 }
 
 case class PieChart[C:ToPoints:Sampler](originalData:C, fields:Option[(String, String)]=None, override val sizes:(Int, Int)=(600, 400), maxPoints:Int = DEFAULT_MAX_POINTS) extends Chart[C](originalData, maxPoints) with Sequencifiable[C] {


### PR DESCRIPTION
Dimple are quite messy, scatter weren't right, grouping is invasive and so on.
C3 now replaces dimple for most basic charts, unless Pie and Dyi so far.

Thanks to C3, grouping is introduced based on field name. New charts are kept reactive to new data.

Added TimeseriesChart which can deal better with Date

cc @vidma -- I was fed up of dimple crappiness... :-)