### PR TITLE
fixes several things related to deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,7 @@ resolvers in ThisBuild ++= Seq(
   Resolver.typesafeIvyRepo("releases"),
   Resolver.typesafeIvyRepo("snapshots"),
   "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos",
+  "mapr" at "http://repository.mapr.com/maven",
   // docker
   "softprops-maven" at "http://dl.bintray.com/content/softprops/maven"
 ) ++ ((sparkResolver, searchSparkResolver, sparkVersion.value) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,24 +25,26 @@ object Dependencies {
   val akkaSlf4j = akkaGroup %% "akka-slf4j" % akkaVersion
 
   val scala_2_1X = "2\\.1([0-9])\\.[0-9]+.*".r
-  val spark_1_X = "[a-zA-Z]*1\\.([0-9]+)\\.([0-9]+).*".r
+  val spark_X_Y = "[a-zA-Z]*([0-9]+)\\.([0-9]+)\\.([0-9]+).*".r
   val extractVs = "[a-zA-Z]*(\\d+)\\.(\\d+)\\.(\\d+).*".r
 
-  val defaultSparkVersion = sys.props.getOrElse("spark.version", "1.6.0")
+  val defaultSparkVersion = sys.props.getOrElse("spark.version", "1.6.1")
   val sparkVersionTuple = defaultSparkVersion match { case extractVs(v, m, p) =>  (v.toInt, m.toInt, p.toInt)}
   val defaultScalaVersion = sys.props.getOrElse("scala.version", "2.10.5") match {
     case x@scala_2_1X("0") => defaultSparkVersion match {
-      case spark_1_X(x, _) if x.toInt < 6 => "2.10.4"
-      case spark_1_X("6", _)              => "2.10.5"
-      case spark_1_X(_, _)                => x
+      case spark_X_Y("1", x, _) if x.toInt < 6 => "2.10.4"
+      case spark_X_Y("1", "6", _)              => "2.10.5"
+      case spark_X_Y("2", _, _)                => "2.10.6"
+      case spark_X_Y(_, _, _)                  => x
     }
     case x@scala_2_1X("1") => defaultSparkVersion match {
-      case spark_1_X("4", "0") => x
-      case spark_1_X("4", _) => "2.11.6"
-      case spark_1_X("5", x) if x.toInt < 2 => "2.11.6"
-      case spark_1_X("5", _) => "2.11.7"
-      case spark_1_X("6", _) => "2.11.7"
-      case spark_1_X(_, _) => x
+      case spark_X_Y("1", "4", "0") => x
+      case spark_X_Y("1", "4", _) => "2.11.6"
+      case spark_X_Y("1", "5", x) if x.toInt < 2 => "2.11.6"
+      case spark_X_Y("1", "5", _) => "2.11.7"
+      case spark_X_Y("1", "6", _) => "2.11.7"
+      case spark_X_Y("2", _, _) => "2.11.8"
+      case spark_X_Y(_, _, _) => x
     }
   }
   val breeze = "org.scalanlp" %% "breeze" % "0.10" excludeAll(
@@ -150,7 +152,7 @@ object Dependencies {
   val commonsExec = "org.apache.commons" % "commons-exec" % "1.3" force()
   val commonsCodec = "commons-codec" % "commons-codec" % "1.10" force()
 
-  val defaultGuavaVersion = sys.props.getOrElse("guava.version", "14.0.1") // 16.0.1 for cassandra connector 1.6-M1
+  val defaultGuavaVersion = sys.props.getOrElse("guava.version", "16.0.1") // 16.0.1 for cassandra connector 1.6-M1
   val guava = "com.google.guava" % "guava" % defaultGuavaVersion force()
   val slf4jLog4j = "org.slf4j" % "slf4j-log4j12" % "1.7.7"
   val log4j = "log4j" % "log4j" % "1.2.17"

--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -121,11 +121,16 @@ object Shared {
         .takeWhile(_ != '-' /*get rid of -SNAPSHOT, -RC or whatever*/)
         .split("\\.")
         .toList
-        .map(_.toInt) match {
+        .map(_.toInt).take(3) match {
           case List(1, y, z) if y <= 3 => "0.5.0"
           case List(1, 4, z) => "0.6.4"
           case List(1, 6, z) => "0.8.2"
           case List(1, y, z) => "0.7.1"
+          case List(2, y, z) =>
+            // need to change to use Alluxio instead...
+            // http://search.maven.org/#search|ga|1|alluxio
+            // http://www.alluxio.com/2016/04/getting-started-with-alluxio-and-spark/
+            "0.7.1"
           case _ => throw new IllegalArgumentException("Bad spark version for tachyon: " + sv)
         }
 


### PR DESCRIPTION
* spark 2.x.y (like 2.0.0-preview) can now be used
* mapr repo for mapr deps
* spark version with weird format after x.y.z

**WARN** 
* Still have to migrate the tachyon stuff to alluxio for 2+
* 2+ spark version doesn't compile yet, API changes need some massage (Dataset, REPL, ...)
* CDH 1.6.0 seems to have backported some 2 stuff hence needs some specific fu ( see #655 )

should fix #656 and #465 

cc @huitseeker @vidma 
@agibsonccc 