### PR TITLE
Changed default port for notebook server to 9001

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help: ## This help dialog.
 all: help
 
 run: ## start server with mode DEV on port 9002
-	sbt ~run -Dhttp.port=9000 # -Dconfig.file=/FULL PATH TO YOUR LOCAL DEV CONF FILE/dev.conf
+	sbt ~run -Dhttp.port=9001 # -Dconfig.file=/FULL PATH TO YOUR LOCAL DEV CONF FILE/dev.conf
 
 console: ## start console
 	sbt console

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ version in ThisBuild <<= (scalaVersion, sparkVersion, hadoopVersion, withHive, w
   s"$SparkNotebookSimpleVersion-scala-$sc-spark-$sv-hadoop-$hv" + (if (h) "-with-hive" else "") + (if (p) "-with-parquet" else "")
 }
 
+play.PlayImport.PlayKeys.playDefaultPort := 9001
+
 updateOptions := updateOptions.value.withCachedResolution(true)
 
 maintainer := DockerProperties.maintainer //Docker

--- a/conf/application.ini
+++ b/conf/application.ini
@@ -1,0 +1,2 @@
+# Default HTTP port when running the spark-notebook server
+-Dhttp.port=9001

--- a/details.md
+++ b/details.md
@@ -143,7 +143,7 @@ Want to try out Spark Notebook? Do these steps.
 * Open a terminal/command window.
 * Change to the root directory of the expanded distribution.
 * Execute the command `bin/spark-notebook` (*NIX) or `bin\spark-notebook` (Windows).
-* Open your browser to [localhost:9000](http://localhost:9000).
+* Open your browser to [localhost:9001](http://localhost:9001).
 
 For more details on getting started, see [Launch](#launch).
 
@@ -233,14 +233,14 @@ If you're a Docker user, the following procedure will be even simpler!
 
 ```
 docker pull andypetrella/spark-notebook:0.6.0-scala-2.10.4-spark-1.4.1-hadoop-2.4.0
-docker run -p 9000:9000 andypetrella/spark-notebook:0.6.0-scala-2.10.4-spark-1.4.1-hadoop-2.4.0
+docker run -p 9001:9001 andypetrella/spark-notebook:0.6.0-scala-2.10.4-spark-1.4.1-hadoop-2.4.0
 ```
 
 ###### boot2docker (Mac OS X)
 On Mac OS X, you need something like _boot2docker_ to use docker. However, port forwarding needs an extra command necessary for it to work (cf [this](http://stackoverflow.com/questions/28381903/spark-notebook-not-loading-with-docker) and [this](http://stackoverflow.com/questions/21653164/map-ports-so-you-can-access-docker-running-apps-from-osx-host) SO questions).
 
 ```
-VBoxManage modifyvm "boot2docker-vm" --natpf1 "tcp-port9000,tcp,,9000,,9000"
+VBoxManage modifyvm "boot2docker-vm" --natpf1 "tcp-port9001,tcp,,9001,,9001"
 ```
 
 
@@ -419,7 +419,7 @@ Before the first launch, it may be necessary to add some settings to `conf/appli
 
 In particular `manager.kernel.vmArgs` can be used to set environment variables for the driver (e.g. `-Dhdp.version=$HDP-Version` if you want to run the Spark Notebook on a **Hortonworks** cluster). These are the settings that you would commonly pass via `spark.driver.extraJavaOptions`.
 
-When the server has been started, you can head to the page `http://localhost:9000` and you'll see something similar to:
+When the server has been started, you can head to the page `http://localhost:9001` and you'll see something similar to:
 ![Notebook list](https://raw.github.com/andypetrella/spark-notebook/master/images/list.png)
 
 From there you can either:
@@ -497,7 +497,7 @@ _Note_: the spark assembly is referred locally in `spark.yarn.jar`, you can also
 
 To run the notebook, it's **important** to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.
 
-The port `9000` being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
+If the port `9001` is already being used by another service, you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
 
 Hence, the final launch is something like this:
 
@@ -583,7 +583,7 @@ _Note_: the spark assembly is referred locally in `spark.yarn.jar`, you can also
 
 To run the notebook, it's **important** to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.
 
-The port `9000` being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
+If the port `9001` is already being used by another service, you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
 
 Hence, the final launch is something like this:
 
@@ -694,7 +694,7 @@ Locate the commented key `override` and paste:
 
 To run the notebook, it's **important** to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.
 
-The port `9000` being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
+If the port `9001` is already being used by another service, you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
 
 Hence, the final launch is something like this (**check** below for how to use `screen` for persistence):
 ```
@@ -1407,7 +1407,7 @@ you should start Spark Notebook with `-Dhadoop.version parameter`, like: `sbt -D
 * some features (like switching output modes of the cell) are activated by keyboard shortcuts that are described at **Help > Keyboard Shortcuts**.
 * running the dist/sbt on a different port: `./bin/spark-notebook -Dhttp.port=8888`
 * running the dist/sbt on a different address: `./bin/spark-notebook -Dhttp.address=example.com`
-* running the dist/sbt on a different context path: `./bin/spark-notebook -Dapplication.context=/spark-notebook`. Then you can browse [http://localhost:9000/spark-notebook](http://localhost:9000/spark-notebook). **NB**: the context path **has** to start wiht `/`.
+* running the dist/sbt on a different context path: `./bin/spark-notebook -Dapplication.context=/spark-notebook`. Then you can browse [http://localhost:9001/spark-notebook](http://localhost:9001/spark-notebook). **NB**: the context path **has** to start wiht `/`.
 
 
 # IMPORTANT

--- a/docs/build_specific_distros.md
+++ b/docs/build_specific_distros.md
@@ -54,7 +54,7 @@ Before the first launch, it may be necessary to add some settings to `conf/appli
 
 In particular `manager.kernel.vmArgs` can be used to set environment variables for the driver (e.g. `-Dhdp.version=$HDP-Version` if you want to run the Spark Notebook on a **Hortonworks** cluster). These are the settings that you would commonly pass via `spark.driver.extraJavaOptions`.
 
-When the server has been started, you can head to the page `http://localhost:9000` and you'll see something similar to:
+When the server has been started, you can head to the page `http://localhost:9001` and you'll see something similar to:
 ![Notebook list](./images/spark-notebook-home.png)
 
 From there you can either:

--- a/docs/clusters_clouds.md
+++ b/docs/clusters_clouds.md
@@ -65,7 +65,7 @@ _Note_: the spark assembly is referred locally in `spark.yarn.jar`, you can also
 
 To run the notebook, it's **important** to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.
 
-The port `9000` being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
+If the port `9001` is already being used by another service, you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
 
 Hence, the final launch is something like this:
 
@@ -151,7 +151,7 @@ _Note_: the spark assembly is referred locally in `spark.yarn.jar`, you can also
 
 To run the notebook, it's **important** to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.
 
-The port `9000` being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
+If the port `9001` is already being used by another service, you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
 
 Hence, the final launch is something like this:
 
@@ -262,7 +262,7 @@ Locate the commented key `override` and paste:
 
 To run the notebook, it's **important** to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.
 
-The port `9000` being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
+If the port `9001` is already being used by another service, you'll need to run it on a different port, below we've arbitrarly chosen `8989`.
 
 Hence, the final launch is something like this (**check** below for how to use `screen` for persistence):
 ```

--- a/docs/exploring_notebook.md
+++ b/docs/exploring_notebook.md
@@ -2,10 +2,10 @@
 
 ## Exploring the Notebook interface
 
-For this introductory guide, we are, we are going to use [core/spark-101](http://localhost:9000/notebooks/core/Spark-101.snb)
-*(for the links in this page to work, we assume that the Spark Notebook is running on localhost on the default port (9000))*
+For this introductory guide, we are, we are going to use [core/spark-101](http://localhost:9001/notebooks/core/Spark-101.snb)
+*(for the links in this page to work, we assume that the Spark Notebook is running on localhost on the default port (9001))*
 
-Click on the folder [core](http://localhost:9000/tree/core) and then click on the [spark-101](http://localhost:9000/notebooks/core/Spark-101.snb) notebook.
+Click on the folder [core](http://localhost:9001/tree/core) and then click on the [spark-101](http://localhost:9001/notebooks/core/Spark-101.snb) notebook.
 
 The Spark Notebook main abstraction is a _cell_. A cell can contain text, in the form of Markdown or Scala/Spark code.
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -17,7 +17,7 @@ Start using the Spark Notebook in less than 5 minutes? Take these steps:
 * Open a terminal/command window
 * Change to the root directory of the expanded distribution
 * Execute the command `bin/spark-notebook` (*NIX) or `bin\spark-notebook` (Windows)
-* Open your browser to [localhost:9000](http://localhost:9000)
+* Open your browser to [localhost:9001](http://localhost:9001)
 
 This procedure will launch a Notebook Server with the default configuration. If all went well, you will see the Notebook browser home page:
 

--- a/docs/using_releases.md
+++ b/docs/using_releases.md
@@ -50,14 +50,14 @@ If you're a Docker user, the following procedure will be even simpler!
 
 ```bash
 docker pull andypetrella/spark-notebook:0.6.0-scala-2.10.4-spark-1.4.1-hadoop-2.4.0
-docker run -p 9000:9000 andypetrella/spark-notebook:0.6.0-scala-2.10.4-spark-1.4.1-hadoop-2.4.0
+docker run -p 9001:9001 andypetrella/spark-notebook:0.6.0-scala-2.10.4-spark-1.4.1-hadoop-2.4.0
 ```
 
 ##### Note: boot2docker (Mac OS X)
 On Mac OS X, you need something like _boot2docker_ to use docker. However, port forwarding needs an extra command necessary for it to work (cf [this](http://stackoverflow.com/questions/28381903/spark-notebook-not-loading-with-docker) and [this](http://stackoverflow.com/questions/21653164/map-ports-so-you-can-access-docker-running-apps-from-osx-host) SO questions).
 
 ```bash
-VBoxManage modifyvm "boot2docker-vm" --natpf1 "tcp-port9000,tcp,,9000,,9000"
+VBoxManage modifyvm "boot2docker-vm" --natpf1 "tcp-port9001,tcp,,9001,,9001"
 ```
 
 

--- a/project/DockerProperties.scala
+++ b/project/DockerProperties.scala
@@ -36,5 +36,5 @@ object DockerProperties extends BuildConf {
   val commands     = Try { asCmdSeq(cfg.getConfigList("docker.commands").asScala.toSeq) }.getOrElse( defaultCommands )
   val volumes      = Try { cfg.getStringList("docker.volumes").asScala.toSeq }.getOrElse( defaultVolumes )
   val registry     = Some(getString("docker.registry", "andypetrella"))
-  val ports        = Try { cfg.getIntList("docker.ports").asScala.toSeq.map { e => e.intValue() } }.getOrElse( Seq(9000, 9443) )
+  val ports        = Try { cfg.getIntList("docker.ports").asScala.toSeq.map { e => e.intValue() } }.getOrElse( Seq(9001, 9443) )
 }

--- a/public/docs/clusters_clouds.html
+++ b/public/docs/clusters_clouds.html
@@ -48,7 +48,7 @@ rm spark-notebook-0.6.0-scala-2.10.4-spark-1.3.1-hadoop-2.4.0-with-hive-with-par
 <p><em>Note</em>: the spark assembly is referred locally in <code>spark.yarn.jar</code>, you can also put it <code>HDFS</code> yourself and refer its path on hdfs.</p>
 <h6 id="run">Run</h6>
 <p>To run the notebook, it's <strong>important</strong> to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.</p>
-<p>The port <code>9000</code> being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen <code>8989</code>.</p>
+<p>The port <code>9001</code> being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen <code>8989</code>.</p>
 <p>Hence, the final launch is something like this:</p>
 <pre><code>export HADOOP_CONF_DIR=/home/hadoop/conf
 export EXTRA_CLASSPATH=/home/hadoop/share/hadoop/common/lib/hadoop-lzo.jar:/home/hadoop/hive/conf
@@ -111,7 +111,7 @@ rm spark-notebook-0.6.0-scala-2.10.4-spark-1.4.1-hadoop-2.6.0-with-hive-with-par
 <p><em>Note</em>: the spark assembly is referred locally in <code>spark.yarn.jar</code>, you can also put it <code>HDFS</code> yourself and refer its path on hdfs.</p>
 <p id="run-1">Run</p>
 <p>To run the notebook, it's <strong>important</strong> to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.</p>
-<p>The port <code>9000</code> being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen <code>8989</code>.</p>
+<p>The port <code>9001</code> being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen <code>8989</code>.</p>
 <p>Hence, the final launch is something like this:</p>
 <pre><code>export HADOOP_CONF_DIR=/etc/hadoop/conf
 export SPARK_HOME=/usr/lib/spark
@@ -198,7 +198,7 @@ cd spark-notebook</code></pre>
 </blockquote>
 <p id="run-2">Run</p>
 <p>To run the notebook, it's <strong>important</strong> to update its classpath with the location of the configuration files for yarn, hadoop and hive, but also the different specific jars that the drivers will require to access the Yarn cluster.</p>
-<p>The port <code>9000</code> being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen <code>8989</code>.</p>
+<p>The port <code>9001</code> being already taken by Hadoop (hdfs), you'll need to run it on a different port, below we've arbitrarly chosen <code>8989</code>.</p>
 <p>Hence, the final launch is something like this (<strong>check</strong> below for how to use <code>screen</code> for persistence):</p>
 <pre><code>export SPARK_LOCAL_IP=$(ec2-metadata -o | cut -d &#39; &#39; -f2)
 export SPARK_LOCAL_HOSTNAME=$(ec2-metadata -h | cut -d &#39; &#39; -f2)

--- a/public/docs/exploring_notebook.html
+++ b/public/docs/exploring_notebook.html
@@ -3,8 +3,8 @@
 </head>
 <body><h1 id="documentation">Documentation</h1>
 <h2 id="exploring-the-notebook-interface">Exploring the Notebook interface</h2>
-<p>For this introductory guide, we are, we are going to use <a href="http://localhost:9000/notebooks/core/Spark-101.snb">core/spark-101</a> <em>(for the links in this page to work, we assume that the Spark Notebook is running on localhost on the default port (9000))</em></p>
-<p>Click on the folder <a href="http://localhost:9000/tree/core">core</a> and then click on the <a href="http://localhost:9000/notebooks/core/Spark-101.snb">spark-101</a> notebook.</p>
+<p>For this introductory guide, we are, we are going to use <a href="http://localhost:9001/notebooks/core/Spark-101.snb">core/spark-101</a> <em>(for the links in this page to work, we assume that the Spark Notebook is running on localhost on the default port (9001))</em></p>
+<p>Click on the folder <a href="http://localhost:9001/tree/core">core</a> and then click on the <a href="http://localhost:9001/notebooks/core/Spark-101.snb">spark-101</a> notebook.</p>
 <p>The Spark Notebook main abstraction is a <em>cell</em>. A cell can contain text, in the form of Markdown or Scala/Spark code.</p>
 <div class="figure">
 <img src="./images/markdown-cell.png" alt="markdown cell" />

--- a/public/docs/quick_start.html
+++ b/public/docs/quick_start.html
@@ -23,7 +23,7 @@
 <li>Open a terminal/command window</li>
 <li>Change to the root directory of the expanded distribution</li>
 <li>Execute the command <code>bin/spark-notebook</code> (*NIX) or <code>bin\spark-notebook</code> (Windows)</li>
-<li>Open your browser to <a href="http://localhost:9000">localhost:9000</a></li>
+<li>Open your browser to <a href="http://localhost:9001">localhost:9001</a></li>
 </ul>
 <p>This procedure will launch a Notebook Server with the default configuration. If all went well, you will see the Notebook browser home page:</p>
 <div class="figure">

--- a/src/templates/etc-default
+++ b/src/templates/etc-default
@@ -15,7 +15,7 @@
 JAVA_OPTS="-Dpidfile.path=/var/run/${{app_name}}/play.pid $JAVA_OPTS"
 # JAVA_OPTS="-Dconfig.file=/etc/${{app_name}}/env.conf $JAVA_OPTS"
 # JAVA_OPTS="-DapplyEvolutions.default=false $JAVA_OPTS"
-# JAVA_OPTS="-Dhttp.port=9000 $JAVA_OPTS"
+# JAVA_OPTS="-Dhttp.port=9001 $JAVA_OPTS"
 # JAVA_OPTS="-Dhttp.address=127.0.0.1 $JAVA_OPTS"
 
 # Setting -Xmx and -Xms in Megabyte


### PR DESCRIPTION
As the default Play port is 9000, we often get conflicts when launching the spark notebook server with HDFS running in local on port 9000 aswell.

I propose to change the default port to **9001**. 

Based on my understanding, spark notebook is always launched via a sbt run, thus we can rely on the addition of `play.PlayImport.PlayKeys.playDefaultPort := 9001` in **build.sbt** to do the trick.

If the user wants to change the default port, they can still use the `-Dhttp.port=` option when launching spark notebook. 

I also updated the docs (apart from everything in _/public/_, I assume it is generated on it's own ?). 