### PR TITLE
Disable buggy dirty cell highlighting

### DIFF
--- a/public/javascripts/notebook/sidebar.js
+++ b/public/javascripts/notebook/sidebar.js
@@ -77,7 +77,8 @@ require(["jquery", "underscore", "base/js/events", "knockout"], function($, _, e
   if (!td.find("table").length) {
     function viewModel() {
       var self = this;
-      self.checkClash = ko.observable(true);
+      // FIXME: disabled as seem to freeze UI, fix or remove the feature
+      self.checkClash = ko.observable(false);
       self.definitions = {};
       self.definitions.data = ko.observableArray([]);
       self.clearDefinitions = function() {


### PR DESCRIPTION
disable buggy #679  . seems to freeze the browser. 

also isn't it distracting the user?

cc @andypetrella 