### PR TITLE
Fix widgets.Flow to return only non-empty items

### DIFF
--- a/modules/common/src/main/scala/notebook/front/widgets/Flow.scala
+++ b/modules/common/src/main/scala/notebook/front/widgets/Flow.scala
@@ -187,7 +187,7 @@ case class Flow() extends Updatable with JsWorld[PipeComponent[_], JsValue] {
         pc
       }
       p
-    }.map { case Some(x) => x }
+    }.collect { case Some(x) => x }
     addAndApply(pcs)
   }
 


### PR DESCRIPTION
took this from `future-master` branch. Doesn't seem related to `Spark 2.0`. 

@andypetrella  why is this change needed?
