### PR TITLE
Enable Hive support automatically

### DIFF
--- a/conf/scripts/init.sc
+++ b/conf/scripts/init.sc
@@ -117,6 +117,8 @@ import scala.util.matching.Regex
   import org.apache.spark.ui.notebook.front.gadgets.SparkMonitor
   @transient var sparkMonitor:Option[SparkMonitor] = _
 
+  private def initScriptLogger = org.slf4j.LoggerFactory.getLogger("init.sc")
+
   def reset(appName:String=notebookName, lastChanges:(SparkConf=>Unit)=(_:SparkConf)=>()):Unit = {
     conf = new SparkConf()
     conf.setMaster(sparkMaster.getOrElse("local[*]"))
@@ -140,11 +142,11 @@ import scala.util.matching.Regex
     // try enable hive support automatically, if notebook was built with Hive (i.e. hive libs available)
     try {
       sessionBuilder = sessionBuilder.enableHiveSupport()
-      println("Will instantiate SparkSession with Hive support")
+      initScriptLogger.info("Will instantiate SparkSession with Hive support")
     } catch {
       // we'll get IllegalArgumentException when Hive libs unavailable
       case exception: IllegalArgumentException =>
-        println(s"Will instantiate SparkSession without Hive support because: ${exception.getMessage}")
+        initScriptLogger.warn(s"Creating a SparkSession without Hive support because:\n${exception.getMessage}")
     }
     sparkSession = sessionBuilder.getOrCreate
 


### PR DESCRIPTION
if spark notebook was built with Hive support, enable it automatically when creating a `sparkSession`.

this simplifies handling of https://github.com/andypetrella/spark-notebook/issues/705 issue, by not requiring users to set `spark.sql.catalogImplementation=hive`.

@andypetrella 
cc @astrauka @ljank 
