### PR TITLE
NBSerializer: refactor, add tests

### DIFF
--- a/app/notebook/export/Markdown.scala
+++ b/app/notebook/export/Markdown.scala
@@ -2,7 +2,8 @@ package notebook.export
 
 import java.io.File
 
-import notebook.NBSerializer.{CodeCell, MarkdownCell, Notebook, Output, ScalaExecuteResult, ScalaOutput, ScalaStream}
+import notebook.NBSerializer.{CodeCell, MarkdownCell, Output, ScalaExecuteResult, ScalaOutput, ScalaStream}
+import notebook.Notebook
 
 object Markdown {
   def toBq(s:String) = s.split("\n").map(s => s"> $s").mkString("\n")

--- a/app/notebook/server/NotebookManager.scala
+++ b/app/notebook/server/NotebookManager.scala
@@ -73,11 +73,10 @@ class NotebookManager(val name: String, val notebookDir: File) {
   }
 
   def copyNotebook(nbPath: String) = {
-    val nbData = getNotebook(nbPath)
-    nbData.map { nb =>
-      val newPath = incrementFileName(nb._4.dropRight(extension.length))
+    getNotebook(nbPath).map { case (_, _, nbData, nbFilePath) =>
+      val newPath = incrementFileName(nbFilePath.dropRight(extension.length))
       val newName = getName(newPath)
-      Notebook.deserialize(nb._3) match {
+      Notebook.deserialize(nbData) match {
         case Some(oldNB) =>
           val newMeta = oldNB.metadata.map(_.copy(id = Notebook.getNewUUID, name = newName))
             .orElse(Some(Metadata(id = Notebook.getNewUUID, name = newName)))

--- a/app/notebook/server/NotebookManager.scala
+++ b/app/notebook/server/NotebookManager.scala
@@ -1,12 +1,12 @@
 package notebook.server
 
 import java.io._
-import java.nio.charset.{StandardCharsets, Charset}
+import java.nio.charset.{Charset, StandardCharsets}
 import java.net.URLDecoder
 import java.text.SimpleDateFormat
 import java.util.Date
 
-import notebook.NBSerializer
+import notebook.Notebook
 import notebook.NBSerializer._
 import org.apache.commons.io.FileUtils
 import play.api.Logger
@@ -54,7 +54,9 @@ class NotebookManager(val name: String, val notebookDir: File) {
     val sep = if (path.last == '/') "" else "/"
     val fpath = name.map(path + sep + _ + extension).getOrElse(incrementFileName(path + sep + "Untitled"))
     val nb = Notebook(
-      Some(new Metadata(getName(fpath),
+      Some(Metadata(
+        id = Notebook.getNewUUID,
+        name = getName(fpath),
         customLocalRepo = customLocalRepo,
         customRepos = customRepos,
         customDeps = customDeps,
@@ -75,9 +77,11 @@ class NotebookManager(val name: String, val notebookDir: File) {
     nbData.map { nb =>
       val newPath = incrementFileName(nb._4.dropRight(extension.length))
       val newName = getName(newPath)
-      NBSerializer.read(nb._3) match {
+      Notebook.deserialize(nb._3) match {
         case Some(oldNB) =>
-          save(newPath, Notebook(oldNB.metadata.map(_.copy(name = newName)), oldNB.cells, oldNB.worksheets, oldNB.autosaved, None), false)
+          val newMeta = oldNB.metadata.map(_.copy(id = Notebook.getNewUUID, name = newName))
+            .orElse(Some(Metadata(id = Notebook.getNewUUID, name = newName)))
+          save(newPath, Notebook(newMeta, oldNB.cells, oldNB.worksheets, oldNB.autosaved, None), false)
           newPath
         case None =>
           newNotebook()
@@ -110,7 +114,8 @@ class NotebookManager(val name: String, val notebookDir: File) {
     Logger.debug(s"rename from path $path to $newpath: old file is ${oldfile.getAbsolutePath}")
     load(path).foreach { notebook =>
       val nb = if (notebook.name != newname) {
-        val meta = notebook.metadata.map(_.copy(name = newname)).orElse(Some(new Metadata(newname)))
+        val meta = notebook.metadata.map(_.copy(name = newname))
+          .orElse(Some(Metadata(id = Notebook.getNewUUID, name = newname)))
         notebook.copy(metadata = meta)
       } else {
         notebook
@@ -118,7 +123,7 @@ class NotebookManager(val name: String, val notebookDir: File) {
       val newfile = notebookFile(newpath)
       Logger.debug(s"rename from path $path to $newpath: new file is ${newfile.getAbsolutePath}")
       oldfile.renameTo(newfile)
-      FileUtils.writeStringToFile(newfile, NBSerializer.write(nb))
+      FileUtils.writeStringToFile(newfile, Notebook.serialize(nb))
     }
     (newname, newpath)
   }
@@ -129,7 +134,7 @@ class NotebookManager(val name: String, val notebookDir: File) {
     if (!overwrite && file.exists()) {
       throw new NotebookExistsException("Notebook " + path + " already exists.")
     }
-    FileUtils.writeStringToFile(file, NBSerializer.write(notebook), "UTF-8")
+    FileUtils.writeStringToFile(file, Notebook.serialize(notebook), "UTF-8")
     val nb = load(path)
     (nb.get.metadata.get.name, path)
   }
@@ -138,7 +143,7 @@ class NotebookManager(val name: String, val notebookDir: File) {
     Logger.info(s"Loading notebook at path $path")
     val file = notebookFile(path)
     if (file.exists())
-      NBSerializer.read(FileUtils.readFileToString(file))
+      Notebook.deserialize(FileUtils.readFileToString(file))
     else
       None
   }

--- a/build.sbt
+++ b/build.sbt
@@ -213,7 +213,7 @@ lazy val sparkNotebookCore = Project(id = "spark-notebook-core", base = file("mo
     libraryDependencies ++= playJson,
     libraryDependencies += slf4jLog4j,
     libraryDependencies += commonsIO,
-    libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   ).settings(sharedSettings: _*)
 
 lazy val sparkNotebook = project.in(file(".")).enablePlugins(play.PlayScala).enablePlugins(SbtWeb)

--- a/modules/core/src/main/scala/notebook/Notebook.scala
+++ b/modules/core/src/main/scala/notebook/Notebook.scala
@@ -1,0 +1,26 @@
+package notebook
+
+import notebook.NBSerializer._
+
+case class Notebook(
+                     metadata: Option[Metadata] = None,
+                     cells: Option[List[Cell]] = Some(Nil),
+                     worksheets: Option[List[Worksheet]] = None,
+                     autosaved: Option[List[Worksheet]] = None,
+                     nbformat: Option[Int]
+                   ) {
+  def name = metadata.map(_.name).getOrElse("Anonymous")
+  def normalizedName: String = {
+    val n = name.toLowerCase.replaceAll("[^\\.a-z0-9_-]", "-")
+    n.dropWhile(_ == '-').reverse.dropWhile(_ == '-').reverse
+  }
+  def updateMetadata(newMeta: Option[Metadata]): Notebook = this.copy(metadata = newMeta)
+}
+
+object Notebook {
+  def getNewUUID: String = java.util.UUID.randomUUID.toString
+
+  def deserialize(str: String): Option[Notebook] = NBSerializer.fromJson(str)
+
+  def serialize(nb: Notebook): String = NBSerializer.toJson(nb)
+}

--- a/modules/core/src/test/scala/notebook/NBSerializerTests.scala
+++ b/modules/core/src/test/scala/notebook/NBSerializerTests.scala
@@ -1,0 +1,128 @@
+package notebook
+
+import notebook.NBSerializer.Metadata
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import play.api.libs.json.{JsNumber, JsObject}
+
+import NBSerializer._
+
+class NBSerializerTests extends WordSpec with Matchers with BeforeAndAfterAll {
+
+  val testId = "foo-bar-loo-lar"
+  val testName = "test-notebook-name"
+  val sparkNotebook = Map("build" -> "unit-tests")
+  val customLocalRepo = Some("local-repo")
+  val customRepos = Some(List("custom-repo"))
+  val customDeps = Some(List(""""org.custom" % "dependency" % "1.0.0""""))
+  val customImports = Some(List("""import org.cusom.dependency.SomeClass"""))
+  val customArgs = Some(List.empty[String])
+  val customSparkConf = Some(JsObject( List(("spark.driverPort", JsNumber(1234))) ))
+  val customVars = Some(Map( "HDFS_ROOT" -> "/tmp", "INTERNAL_DOCS" ->  "confidential"))
+
+  val metadata = new Metadata(
+    id = testId,
+    name = testName,
+    user_save_timestamp =  new DateTime(1999, 9, 9, 9, 9, 9, DateTimeZone.getDefault).toDate,
+    auto_save_timestamp =  new DateTime(2001, 1, 1, 0, 0, 0, DateTimeZone.getDefault).toDate,
+    sparkNotebook = Some(sparkNotebook),
+    customLocalRepo = customLocalRepo,
+    customRepos = customRepos,
+    customDeps = customDeps,
+    customImports = customImports,
+    customArgs = customArgs,
+    customSparkConf = customSparkConf,
+    customVars = customVars
+  )
+
+  val notebookSer =
+    """{
+      |  "metadata" : {
+      |    "id" : "foo-bar-loo-lar",
+      |    "name" : "test-notebook-name",
+      |    "user_save_timestamp" : "1999-09-09T09:09:09.000Z",
+      |    "auto_save_timestamp" : "2001-01-01T00:00:00.000Z",
+      |    "language_info" : {
+      |      "name" : "scala",
+      |      "file_extension" : "scala",
+      |      "codemirror_mode" : "text/x-scala"
+      |    },
+      |    "trusted" : true,
+      |    "sparkNotebook" : {
+      |      "build" : "unit-tests"
+      |    },
+      |    "customLocalRepo" : "local-repo",
+      |    "customRepos" : [ "custom-repo" ],
+      |    "customDeps" : [ "\"org.custom\" % \"dependency\" % \"1.0.0\"" ],
+      |    "customImports" : [ "import org.cusom.dependency.SomeClass" ],
+      |    "customArgs" : [ ],
+      |    "customSparkConf" : {
+      |      "spark.driverPort" : 1234
+      |    },
+      |    "customVars" : {
+      |      "HDFS_ROOT" : "/tmp",
+      |      "INTERNAL_DOCS" : "confidential"
+      |    }
+      |  },
+      |  "cells" : [ ]
+      |}""".stripMargin
+
+  val notebookWithContent = Notebook(Some(metadata), nbformat = None)
+
+  "Notebook" should {
+    "serialize a notebook as a valid JSON" in {
+      val nb = Notebook.serialize(notebookWithContent)
+      nb shouldBe notebookSer
+    }
+
+    "deserialize a json encoded notebook as a valid object" in {
+      val ser = Notebook.deserialize(notebookSer)
+      ser shouldBe Some(notebookWithContent)
+    }
+
+    "fail to deserialize an empty Json" in {
+      an [NotebookDeserializationError] should be thrownBy {
+        Notebook.deserialize("{}")
+      }
+    }
+
+    "fail to deserialize invalid Json" in {
+      an [NotebookDeserializationError] should be thrownBy {
+        Notebook.deserialize("{:=")
+      }
+    }
+
+    "serialize to a diff-friendly format" in {
+      val origNotebook = Notebook(Some(metadata), nbformat = None)
+      val deltaNotebook = Notebook(Some(metadata.copy(customLocalRepo = Some("other-local-repo"))), nbformat = None)
+
+      val origNbSer = Notebook.serialize(origNotebook)
+      val deltaNbSer = Notebook.serialize(deltaNotebook)
+
+      val toLines: String => Array[String] = s => s.split("\n")
+
+      val nbDiff = toLines(deltaNbSer).toSet diff toLines(origNbSer).toSet
+      nbDiff.head should include ("other-local-repo")
+      nbDiff.head should not include ("metadata") // to exclude that the diff is the whole doc
+    }
+
+    "be able to read older snb formats" when {
+      val oldFormatNotebookSer =
+        """{
+          |  "metadata" : {
+          |    "name" : "test-notebook-name",
+          |    "user_save_timestamp" : "1999-09-09T09:09:09.000Z",
+          |    "auto_save_timestamp" : "2001-01-01T00:00:00.000Z"
+          |  }
+          |}""".stripMargin
+      val oldDeserialized = Notebook.deserialize(oldFormatNotebookSer)
+
+      "notebook.metadata.id was undefined -> it gets a new random UUID" in {
+        oldDeserialized.get.metadata.get.id.length shouldBe 36
+      }
+      "notebook.cells is undefined -> it becomes an empty list" in {
+        oldDeserialized.get.cells.get shouldBe List.empty
+      }
+    }
+  }
+}


### PR DESCRIPTION
- [x] Add `notebook.metadata.id` an UUID  that will be useful for identifying the same notebook  after a rename
- [x] Add `sparkNotebook, customSparkConf, customVars` as notebook metadata keys
- [x] Add tests for NBSerializer
- [x] Simplify NBSerializer code

@maasg @andypetrella 