### PR TITLE
Don't store Plotly control buttons as output Svgs

### DIFF
--- a/public/ipython/notebook/js/outputarea.js
+++ b/public/ipython/notebook/js/outputarea.js
@@ -996,9 +996,19 @@ define([
                     if (!o.data_list) o.data_list  = {};
                     o.data_list["application/svg+pngbase64"] = [];
                     var h = o.data["text/html"];
-                    var svg = this.element.find("svg");
-                    for (var i in svg) {
-                        var s = svg[i];
+
+                    var svgs = this.element
+                      .find("svg")
+                      // exclude buttons and special SVGs from Plotly
+                      .filter(function (index, svg) {
+                        var isPlotly = $(svg).parents(".plotly").length > 0;
+                        var isPlotyButton = $(svg).parents(".modebar").length > 0;
+                        var isWeirdSvg = $(svg).find(".zoomlayer, .infolayer, .hoverlayer").length > 0;
+                        return  !isPlotly || (!isPlotyButton && !isWeirdSvg);
+                      });
+
+                    for (var i in svgs) {
+                        var s = svgs[i];
                         try {
                             var p = new Promise(function(resolve, reject) {
                                 svgAsPng.svgAsPngUri(s, {}, function(uri) {


### PR DESCRIPTION
a quick fix for Plotly to not save rubish as output PNGs 
(could be improved later, e.g. for other chart types).

Markdown after fix:

---

<img width="458" alt="screen shot 2016-12-15 at 23 03 22" src="https://cloud.githubusercontent.com/assets/213426/21241972/bd7224f4-c31a-11e6-8a02-0a7cdcafad3c.png">


--- 

Markdown before:

<img width="463" alt="screen shot 2016-12-15 at 23 05 42" src="https://cloud.githubusercontent.com/assets/213426/21242034/0d86d822-c31b-11e6-8d21-d34d7b36d4fe.png">
... and there were many rubish images below this one...

cc @maasg @andypetrella 
