### PR TITLE
Add SparkClosureUtil for debugging spark serialization of closures

### DIFF
--- a/modules/spark/src/main/scala/notebook/spark/util/SparkClosureUtil.scala
+++ b/modules/spark/src/main/scala/notebook/spark/util/SparkClosureUtil.scala
@@ -4,6 +4,19 @@ import scala.reflect.runtime.universe
 import org.apache.log4j.AppenderSkeleton
 import org.apache.log4j.spi.LoggingEvent
 
+/**
+ * A closure cleaning util which allows accessing the log output by Spark's `ClosureCleaner`.
+ * This object is responsible to evict unnecessary objects from the closure context of an object or function.
+ * Also it will test if it is serializable.
+ * However, there is no clear information we can get out naturally out of this helper, unless we can have 
+ * access to the logs issued internally. This gives clear information about what's going on, and specially 
+ * *wrong* when it's the case.
+ *
+ * It Registers the given `appendTo` function to the logger of the Spark's ClosureCleaner. 
+ * The default is to `println` to stdout.
+ * Example: in a spark notebook, we can use a `widgets.ul` in a cell and use the object's method `append` to
+ * print in the notebook the logs from the cleaner.
+ **/
 class SparkClosureUtil(appendTo: String => Unit = println) 
   extends org.apache.spark.util.notebook.hack.SparkClosureUtilHack {
 }

--- a/modules/spark/src/main/scala/notebook/spark/util/SparkClosureUtil.scala
+++ b/modules/spark/src/main/scala/notebook/spark/util/SparkClosureUtil.scala
@@ -1,0 +1,59 @@
+package notebook.spark.util
+
+import scala.reflect.runtime.universe
+import org.apache.log4j.AppenderSkeleton
+import org.apache.log4j.spi.LoggingEvent
+
+class SparkClosureUtil(appendTo: String => Unit = println) {
+
+  // get the closure cleaner
+  private val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
+  private val module = runtimeMirror.staticModule("org.apache.spark.util.ClosureCleaner")
+  private val obj = runtimeMirror.reflectModule(module).instance
+
+  // make the clean method accessible
+  private val cleanMethods = obj.getClass.getDeclaredMethods().filter(_.getName == "clean")
+  assert(cleanMethods.size == 1)
+
+  def clean(o:Object) = cleanMethods.head.invoke(obj, o, java.lang.Boolean.TRUE, java.lang.Boolean.TRUE)
+
+  // open the logger from the closure cleaner
+  private val logMethod = obj.getClass.getDeclaredMethod("log")
+  logMethod.setAccessible(true)
+  private val logSlf4J = logMethod.invoke(obj)
+  require(logSlf4J.isInstanceOf[org.slf4j.Logger])
+  private val loggerInF = logSlf4J.getClass.getDeclaredField("logger")
+  loggerInF.setAccessible(true)
+  private val loggerIn = loggerInF.get(logSlf4J)
+  require(loggerIn.isInstanceOf[org.apache.log4j.Logger])
+  private val logger = loggerIn.asInstanceOf[org.apache.log4j.Logger]
+
+  // define appender to show the cleaning logs
+  class HackAppender extends AppenderSkeleton {
+    override def append(event:LoggingEvent) {
+      appendTo(event.getMessage.toString)
+    }
+    override def close() {
+    }
+    override def requiresLayout() = {
+      false;
+    }
+  }
+  // create appender added to logger and the capacity to restore the initial state
+  private val ulappender = new HackAppender()
+  ulappender.setThreshold(org.apache.log4j.Level.DEBUG)
+  ulappender.activateOptions()
+  logger.addAppender(ulappender)
+
+  private val restoreLogger = {
+    val level = logger.getLevel
+    () => {
+      logger.removeAppender(ulappender)
+      logger.setLevel(level)
+    }
+  }
+
+  logger.setLevel(org.apache.log4j.Level.DEBUG)
+
+  lazy val restore = restoreLogger()
+}

--- a/modules/spark/src/main/scala/notebook/spark/util/SparkClosureUtil.scala
+++ b/modules/spark/src/main/scala/notebook/spark/util/SparkClosureUtil.scala
@@ -4,56 +4,6 @@ import scala.reflect.runtime.universe
 import org.apache.log4j.AppenderSkeleton
 import org.apache.log4j.spi.LoggingEvent
 
-class SparkClosureUtil(appendTo: String => Unit = println) {
-
-  // get the closure cleaner
-  private val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
-  private val module = runtimeMirror.staticModule("org.apache.spark.util.ClosureCleaner")
-  private val obj = runtimeMirror.reflectModule(module).instance
-
-  // make the clean method accessible
-  private val cleanMethods = obj.getClass.getDeclaredMethods().filter(_.getName == "clean")
-  assert(cleanMethods.size == 1)
-
-  def clean(o:Object) = cleanMethods.head.invoke(obj, o, java.lang.Boolean.TRUE, java.lang.Boolean.TRUE)
-
-  // open the logger from the closure cleaner
-  private val logMethod = obj.getClass.getDeclaredMethod("log")
-  logMethod.setAccessible(true)
-  private val logSlf4J = logMethod.invoke(obj)
-  require(logSlf4J.isInstanceOf[org.slf4j.Logger])
-  private val loggerInF = logSlf4J.getClass.getDeclaredField("logger")
-  loggerInF.setAccessible(true)
-  private val loggerIn = loggerInF.get(logSlf4J)
-  require(loggerIn.isInstanceOf[org.apache.log4j.Logger])
-  private val logger = loggerIn.asInstanceOf[org.apache.log4j.Logger]
-
-  // define appender to show the cleaning logs
-  class HackAppender extends AppenderSkeleton {
-    override def append(event:LoggingEvent) {
-      appendTo(event.getMessage.toString)
-    }
-    override def close() {
-    }
-    override def requiresLayout() = {
-      false;
-    }
-  }
-  // create appender added to logger and the capacity to restore the initial state
-  private val ulappender = new HackAppender()
-  ulappender.setThreshold(org.apache.log4j.Level.DEBUG)
-  ulappender.activateOptions()
-  logger.addAppender(ulappender)
-
-  private val restoreLogger = {
-    val level = logger.getLevel
-    () => {
-      logger.removeAppender(ulappender)
-      logger.setLevel(level)
-    }
-  }
-
-  logger.setLevel(org.apache.log4j.Level.DEBUG)
-
-  lazy val restore = restoreLogger()
+class SparkClosureUtil(appendTo: String => Unit = println) 
+  extends org.apache.spark.util.notebook.hack.SparkClosureUtilHack {
 }

--- a/modules/spark/src/main/scala/notebook/spark/util/hack/SparkClosureUtilHack.scala
+++ b/modules/spark/src/main/scala/notebook/spark/util/hack/SparkClosureUtilHack.scala
@@ -1,0 +1,58 @@
+package org.apache.spark.util.notebook.hack
+
+import scala.reflect.runtime.universe
+import org.apache.log4j.AppenderSkeleton
+import org.apache.log4j.spi.LoggingEvent
+
+trait SparkClosureUtilHack {
+  
+  private val CC = org.apache.spark.util.ClosureCleaner
+
+  def appendTo: String => Unit = println
+
+  def clean(o:Object) = {
+    CC.clean(o, java.lang.Boolean.TRUE, java.lang.Boolean.TRUE)
+    // if we reach this point... it's good!
+    "Object cleaned and serializable!"
+  }
+
+  // open the logger from the closure cleaner
+  private val logMethod = CC.getClass.getDeclaredMethod("log")
+  logMethod.setAccessible(true)
+  private val logSlf4J = logMethod.invoke(CC)
+  require(logSlf4J.isInstanceOf[org.slf4j.Logger])
+  private val loggerInF = logSlf4J.getClass.getDeclaredField("logger")
+  loggerInF.setAccessible(true)
+  private val loggerIn = loggerInF.get(logSlf4J)
+  require(loggerIn.isInstanceOf[org.apache.log4j.Logger])
+  private val logger = loggerIn.asInstanceOf[org.apache.log4j.Logger]
+
+  // define appender to show the cleaning logs
+  class HackAppender extends AppenderSkeleton {
+    override def append(event:LoggingEvent) {
+      appendTo(event.getMessage.toString)
+    }
+    override def close() {
+    }
+    override def requiresLayout() = {
+      false;
+    }
+  }
+  // create appender added to logger and the capacity to restore the initial state
+  private val ulappender = new HackAppender()
+  ulappender.setThreshold(org.apache.log4j.Level.DEBUG)
+  ulappender.activateOptions()
+  logger.addAppender(ulappender)
+
+  private val restoreLogger = {
+    val level = logger.getLevel
+    () => {
+      logger.removeAppender(ulappender)
+      logger.setLevel(level)
+    }
+  }
+
+  logger.setLevel(org.apache.log4j.Level.DEBUG)
+
+  lazy val restore = restoreLogger()
+}


### PR DESCRIPTION
Added object capable of logging closure cleaning stuff and to ensure a function or an object is serializable
![image](https://cloud.githubusercontent.com/assets/663344/21351444/cfee4eaa-c6bc-11e6-93b1-3ed1c1a91a0f.png)

cc @vidma @maasg 