### PR TITLE
Better header for download as Spark Notebook

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -659,6 +659,7 @@ object Application extends Controller {
             }
             Ok(json).withHeaders(
               HeaderNames.CONTENT_DISPOSITION → s"""attachment; filename="$path" """,
+              HeaderNames.CONTENT_TYPE → "application/force-download",
               HeaderNames.CONTENT_ENCODING → "UTF-8",
               HeaderNames.LAST_MODIFIED → lastMod
             )


### PR DESCRIPTION
Prevent some browsers (like Safari) to append `json` extension to filename.