### PR TITLE
Simplify SN module jar versioning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,7 @@ scalaVersion := defaultScalaVersion
 
 val SparkNotebookSimpleVersion = "0.8.0-SNAPSHOT"
 
-version in ThisBuild <<= (scalaVersion, sparkVersion, hadoopVersion, withHive, withParquet) { (sc, sv, hv, h, p) =>
-  s"$SparkNotebookSimpleVersion-scala-$sc-spark-$sv-hadoop-$hv" + (if (h) "-with-hive" else "") + (if (p) "-with-parquet" else "")
-}
+version in ThisBuild := SparkNotebookSimpleVersion
 
 play.PlayImport.PlayKeys.playDefaultPort := 9001
 
@@ -55,8 +53,6 @@ enablePlugins(DebianPlugin)
 name in Debian := MainProperties.name
 
 maintainer in Debian := DebianProperties.maintainer
-
-packageSummary in Debian := "Data Fellas Spark-notebook"
 
 packageDescription := "Interactive and Reactive Data Science using Scala and Spark."
 
@@ -146,6 +142,8 @@ compileOrder := CompileOrder.Mixed
 
 publishMavenStyle := false
 
+publishArtifact in Test := false
+
 javacOptions ++= Seq("-Xlint:deprecation", "-g")
 
 scalacOptions ++= Seq("-deprecation", "-feature")
@@ -207,7 +205,6 @@ lazy val sbtDependencyManager = Project(id = "sbt-dependency-manager", base = fi
     scalaVersion := defaultScalaVersion,
     organization := "io.kensu",
     version := version.value,
-    publishArtifact in Test := false,
     publishMavenStyle := true
   ).settings(
     Extra.sbtDependencyManagerSettings
@@ -218,7 +215,6 @@ lazy val sparkNotebookCore = Project(id = "spark-notebook-core", base = file("mo
     scalaVersion := defaultScalaVersion,
     organization := "guru.data-fellas",
     version := version.value,
-    publishArtifact in Test := false,
     publishMavenStyle := true,
     libraryDependencies ++= playJson,
     libraryDependencies += slf4jLog4j,
@@ -239,6 +235,9 @@ lazy val sparkNotebook = project.in(file(".")).enablePlugins(play.PlayScala).ena
     },
     // configure the "universal" distribution package (i.e. spark-notebook.zip)
     mappings in Universal ++= directory("notebooks"),
+    version in Universal <<= (version in ThisBuild, scalaVersion, sparkVersion, hadoopVersion, withHive, withParquet) { (v, sc, sv, hv, h, p) =>
+                                s"$v-scala-$sc-spark-$sv-hadoop-$hv" + (if (h) "-with-hive" else "") + (if (p) "-with-parquet" else "")
+                              },
     mappings in Docker ++= directory("notebooks")
   )
   .settings(includeFilter in(Assets, LessKeys.less) := "*.less")
@@ -270,7 +269,6 @@ lazy val subprocess = Project(id="subprocess", base=file("modules/subprocess"))
     }
   )
   .settings(sharedSettings: _*)
-  .settings(sparkSettings: _*)
   .settings(
     Extra.subprocessSettings
   )
@@ -294,6 +292,9 @@ lazy val observable = Project(id = "observable", base = file("modules/observable
 
 lazy val common = Project(id = "common", base = file("modules/common"))
   .dependsOn(observable, sbtDependencyManager)
+  .settings(
+    version  <<= (version in ThisBuild, sparkVersion) { (v,sv) => s"${v}_$sv" }
+  )
   .settings(
     libraryDependencies ++= Seq(
       akka,
@@ -339,6 +340,9 @@ lazy val common = Project(id = "common", base = file("modules/common"))
 
 lazy val spark = Project(id = "spark", base = file("modules/spark"))
   .dependsOn(common, subprocess, observable)
+  .settings(
+    version  <<= (version in ThisBuild, sparkVersion) { (v,sv) => s"${v}_$sv" }
+  )
   .settings(
     libraryDependencies ++= Seq(
       akkaRemote,

--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -16,6 +16,7 @@ object Shared {
   lazy val withParquet = SettingKey[Boolean]("x-with-parquet")
 
   lazy val sharedSettings: Seq[Def.Setting[_]] = Seq(
+    publishArtifact in Test := false,
     scalaVersion := defaultScalaVersion,
     sparkVersion := defaultSparkVersion,
     hadoopVersion := defaultHadoopVersion,


### PR DESCRIPTION
- jars will have short real versions now, e.g `core-0.7.1`, `kernel-0.7.1_1.6.1` (instead of long ones)
- the zip package will retain the same full name as earlier `spark-notebook-0.7.1-SNAPSHOT-scala-2.10.4-spark-1.5.2-hadoop-2.6.0-cdh5.5.0-with-hive-with-parquet.zip`



@maasg @andypetrella , 🚢  ?
I this should be fine, or do we use these long jar/module versions like `spark-notebook-0.7.1-SNAPSHOT-scala-2.10.4-spark-1.5.2-hadoop-2.6.0-cdh5.5.0-with-hive-with-parquet` anywhere?

`sbt clean dist` output (subset):
```
[info] Packaging ./target/spark-notebook-0.8.0-SNAPSHOT-assets.jar ...
[info] Packaging ./target/scala-2.10/spark-notebook_2.10-0.8.0-SNAPSHOT.jar ...
[info] Packaging ./modules/core/target/scala-2.10/spark-notebook-core_2.10-0.8.0-SNAPSHOT.jar ...
[info] Packaging ./modules/subprocess/target/scala-2.10/subprocess_2.10-0.8.0-SNAPSHOT.jar ...
[info] Packaging ./modules/observable/target/scala-2.10/observable_2.10-0.8.0-SNAPSHOT.jar ...
[info] Packaging ./modules/sbt-dependency-manager/target/scala-2.10/sbt-dependency-manager_2.10-0.8.0-SNAPSHOT.jar ...
[info] Packaging ./modules/common/target/scala-2.10/common_2.10-0.8.0-SNAPSHOT_1.6.2.jar ...
[info] Packaging ./modules/spark/target/scala-2.10/spark_2.10-0.8.0-SNAPSHOT_1.6.2.jar ...
[info] Packaging ./modules/kernel/target/scala-2.10/kernel_2.10-0.8.0-SNAPSHOT.jar ...

[info] Your package is ready in /Users/vidma-vinted/kensu/spark-notebook/target/universal/spark-notebook-0.8.0-SNAPSHOT-scala-2.10.5-spark-1.6.2-hadoop-2.6.0-cdh5.8.0-with-hive-with-parquet.zip
```