### PR TITLE
Simplify SN module jar versioning (2.0)

### DIFF
--- a/project/Shared.scala
+++ b/project/Shared.scala
@@ -14,6 +14,7 @@ object Shared {
   lazy val withHive = SettingKey[Boolean]("x-with-hive")
 
   lazy val sharedSettings: Seq[Def.Setting[_]] = Seq(
+    publishArtifact in Test := false,
     scalaVersion := defaultScalaVersion,
     sparkVersion := defaultSparkVersion,
     hadoopVersion := defaultHadoopVersion,


### PR DESCRIPTION
based on #791 

- jars will have short real versions now, e.g `core-0.7.1`, `kernel-0.7.1_1.6.1` (instead of long ones)
- the zip package will retain the same full name as earlier `spark-notebook-0.6.2-SNAPSHOT-scala-2.10.4-spark-1.5.2-hadoop-2.6.0-cdh5.5.0-with-hive-with-parquet.zip`


```
[info] Your package is ready in ./spark-notebook/target/universal/spark-notebook-0.8.0-SNAPSHOT-scala-2.11.8-spark-2.0.1-hadoop-2.6.0-cdh5.8.0-with-hive.zip
```
cc @maasg 
