### PR TITLE
fix jdk1.8 ot use backport

### DIFF
--- a/project/DockerProperties.scala
+++ b/project/DockerProperties.scala
@@ -13,7 +13,7 @@ object DockerProperties extends BuildConf {
 
   private val defaultCommands: Seq[Cmd] = Seq(
     Cmd("USER", "root"),
-    Cmd("RUN", s"apt-get update --fix-missing && apt-get install -y --no-install-recommends openjdk-8-jdk"),
+    Cmd("RUN", s"apt-get update --fix-missing && apt-get install -y -t jessie-backports --no-install-recommends openjdk-8-jdk"),
     Cmd("ENV", "JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64"),
     Cmd("RUN", s"apt-get install -y wget curl")
   )


### PR DESCRIPTION
conflict exist with ca-certificates and openjdk1.8, we need to use jessie-backports in apt install.