### PR TITLE
Make cells not-editable in read_only/viewer modes

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -459,7 +459,6 @@ object Application extends Controller {
         "read-only" -> read_only, // FIXME
         "notebook-name" -> notebookManager.name,
         "notebook-path" -> path,
-        "notebook-writable" -> "true", //FIXME
         "presentation" -> presentation.getOrElse("edit")
       ),
       Some("notebook")

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -58,14 +58,15 @@ object Application extends Controller {
 
   private implicit val GetClustersTimeout = Timeout(60 seconds)
 
+  val viewer = config.viewer
+
   val project = notebookManager.name
   val base_project_url = current.configuration.getString("application.context").getOrElse("/")
-  val autoStartKernel = current.configuration.getBoolean("manager.kernel.autostartOnNotebookOpen").getOrElse(true)
+  val autoStartKernel = current.configuration.getBoolean("manager.kernel.autostartOnNotebookOpen").getOrElse(true) && !viewer;
   val kernelKillTimeout = current.configuration.getMilliseconds("manager.kernel.killTimeout")
   val base_kernel_url = "/"
   val base_observable_url = "observable"
-  val read_only = false.toString
-  val viewer = config.viewer
+  val read_only = viewer.toString
 
   //  TODO: Ugh...
   val terminals_available = false.toString // TODO
@@ -455,10 +456,10 @@ object Application extends Controller {
         "base-project-url" -> base_project_url,
         "base-kernel-url" -> base_kernel_url,
         "base-observable-url" -> ws_url(Some(base_observable_url)),
-        "read-only" -> read_only,
+        "read-only" -> read_only, // FIXME
         "notebook-name" -> notebookManager.name,
         "notebook-path" -> path,
-        "notebook-writable" -> "true",
+        "notebook-writable" -> "true", //FIXME
         "presentation" -> presentation.getOrElse("edit")
       ),
       Some("notebook")
@@ -670,7 +671,7 @@ object Application extends Controller {
                 "name" → nbname,
                 "path" → fpath, //FIXME
                 "autoStartKernel" -> autoStartKernel,
-                "writable" -> true //TODO
+                "writable" -> !viewer
               )
             } else {
               j

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -66,7 +66,7 @@ object Application extends Controller {
   val kernelKillTimeout = current.configuration.getMilliseconds("manager.kernel.killTimeout")
   val base_kernel_url = "/"
   val base_observable_url = "observable"
-  val read_only = viewer.toString
+  val read_only = viewer
 
   //  TODO: Ugh...
   val terminals_available = false.toString // TODO
@@ -431,7 +431,7 @@ object Application extends Controller {
     }.get
   }
 
-  def openNotebook(p: String, presentation: Option[String]) = Action { implicit request =>
+  def openNotebook(p: String, presentation: Option[String], read_only: Option[Int]) = Action { implicit request =>
     val path = URLDecoder.decode(p, UTF_8)
     Logger.info(s"View notebook '$path', presentation: '$presentation'")
     val wsPath = base_project_url match {
@@ -456,7 +456,7 @@ object Application extends Controller {
         "base-project-url" -> base_project_url,
         "base-kernel-url" -> base_kernel_url,
         "base-observable-url" -> ws_url(Some(base_observable_url)),
-        "read-only" -> read_only, // FIXME
+        "read-only" -> (this.read_only || read_only.getOrElse(0) == 1).toString, // FIXME
         "notebook-name" -> notebookManager.name,
         "notebook-path" -> path,
         "presentation" -> presentation.getOrElse("edit")
@@ -609,7 +609,7 @@ object Application extends Controller {
         "project" → project,
         "base-project-url" → base_project_url,
         "base-kernel-url" → base_kernel_url,
-        "read-only" → read_only,
+        "read-only" → read_only.toString,
         "base-url" → base_project_url,
         "notebook-path" → path,
         "viewer_mode" → config.viewer.toString,

--- a/app/views/default.scala.html
+++ b/app/views/default.scala.html
@@ -155,14 +155,16 @@
         @site
         <footer class="footer">
           <div class="container">
-            <p class="text-muted">Build: | @{_root_.notebook.BuildInfo.toMap.toList.sortBy(_._1).map{
+          @if(!_root_.utils.AppUtils.notebookConfig.viewer) {
+              <p class="text-muted">Build: | @{_root_.notebook.BuildInfo.toMap.toList.sortBy(_._1).map{
                 case (k, Some(v)) => <span>&nbsp;<strong>{k}</strong>-<em>{v}</em>&nbsp;|</span>
                 case (k, None) => <span>&nbsp;<strong>{k}</strong>-<em>Unknown...</em>&nbsp;|</span>
                 case (k, v) if k.trim.matches("^x[A-Z].*$") => <span>&nbsp;<strong>{k.drop(1).head.toString.toLowerCase+k.drop(1).tail}</strong>-<em>{v}</em>&nbsp;|</span>
                 case (k, v) => <span>&nbsp;<strong>{k}</strong>-<em>{v}</em>&nbsp;|</span>
-              }
-            }.
-            </p>
+                  }
+                }.
+              </p>
+          }
           </div>
         </footer>
         </div>

--- a/conf/routes
+++ b/conf/routes
@@ -35,8 +35,8 @@ PUT            /api/contents/*path                       controllers.Application
 DELETE         /api/contents/*path                       controllers.Application.deleteNotebook(path:String)
 
 # The presentation parameter is optional. E.g. /notebooks/abc.snb?presentation=report
-GET            /notebooks/$snb<.+\.snb>                  controllers.Application.openNotebook(snb:String, presentation: Option[String])
-GET            /edit/:snb                                controllers.Application.openNotebook(snb:String, presentation: Option[String])
+GET            /notebooks/$snb<.+\.snb>                  controllers.Application.openNotebook(snb:String, presentation: Option[String], read_only: Option[Int])
+GET            /edit/:snb                                controllers.Application.openNotebook(snb:String, presentation: Option[String], read_only: Option[Int])
 GET            /notebooks/                               controllers.Application.dash(path:String="/")
 GET            /notebooks/*path                          controllers.Application.dash(path:String)
 

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -166,3 +166,8 @@ div.output_area pre { color: #666; }
 .cm-sql-inside-scala-mode {
   background-color: #fffdea;
 }
+
+
+body[data-read-only="true"] .cell .progress, body[data-read-only="true"] #maintoolbar, body[data-read-only="true"] #menubar-container {
+  display: none !important; visibility: hidden!important;
+}

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -209,6 +209,7 @@ define([
             if (that.keyboard_manager) {
                 that.keyboard_manager.enable();
             }
+            that.code_mirror.setOption('readOnly', !that.kernel.notebook.writable);
         });
         this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this));
         $(this.code_mirror.getInputField()).attr("spellcheck", "false");

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -209,7 +209,7 @@ define([
             if (that.keyboard_manager) {
                 that.keyboard_manager.enable();
             }
-            that.code_mirror.setOption('readOnly', !that.kernel.notebook.writable);
+            that.code_mirror.setOption('readOnly', !that.notebook.writable);
         });
         this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this));
         $(this.code_mirror.getInputField()).attr("spellcheck", "false");

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -111,7 +111,8 @@ define([
         this._widgets_live = true;
 
         Cell.apply(this,[{
-            config: $.extend({}, CodeCell.options_default),
+            // this needs a deep merge to pass this.config.cm_config.readOnly
+            config: $.extend(true, {}, CodeCell.options_default, this.config),
             keyboard_manager: options.keyboard_manager,
             events: this.events}]);
 
@@ -209,7 +210,6 @@ define([
             if (that.keyboard_manager) {
                 that.keyboard_manager.enable();
             }
-            that.code_mirror.setOption('readOnly', !that.notebook.writable);
         });
         this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this));
         $(this.code_mirror.getInputField()).attr("spellcheck", "false");

--- a/public/ipython/notebook/js/notebook.js
+++ b/public/ipython/notebook/js/notebook.js
@@ -2189,6 +2189,10 @@ define([
      */
     Notebook.prototype.load_notebook_success = function (data) {
         var failed, msg;
+        // we want cell/cm_config options to be set before creating them from JSON...
+        this.writable = data.writable && !this.is_read_only();
+        this.config.cm_config = { readOnly: !this.writable && "nocursor" };
+
         try {
             this.fromJSON(data);
         } catch (e) {
@@ -2247,7 +2251,6 @@ define([
         }
         this.set_dirty(false);
         this.scroll_to_top();
-        this.writable = data.writable && !this.is_read_only();
 
         // to save resources eagerly load the kernel only if configured-so in application.conf
         // must automatically start kernel it was requested to recompute the whole notebook immediately

--- a/public/ipython/notebook/js/notebook.js
+++ b/public/ipython/notebook/js/notebook.js
@@ -2293,7 +2293,7 @@ define([
             this.nbformat_minor = nbmodel.nbformat_minor;
         }
 
-        if (this.session === null) {
+        if (this.session === null && this.autoStartKernel) {
             var kernel_name;
             if (this.metadata.kernelspec) {
                 var kernelspec = this.metadata.kernelspec || {};
@@ -2303,9 +2303,7 @@ define([
             }
             if (kernel_name) {
                 // setting kernel_name here triggers start_session
-                if (this.autoStartKernel) {
-                    this.kernel_selector.set_kernel(kernel_name);
-                }
+                this.kernel_selector.set_kernel(kernel_name);
             } else {
                 // start a new session with the server's default kernel
                 // spec_changed events will fire after kernel is loaded

--- a/public/ipython/notebook/js/textcell.js
+++ b/public/ipython/notebook/js/textcell.js
@@ -105,7 +105,6 @@ define([
             if (that.keyboard_manager) {
                 that.keyboard_manager.enable();
             }
-          that.code_mirror.setOption('readOnly', !that.notebook.writable);
         });
         this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this))
         // The tabindex=-1 makes this div focusable.

--- a/public/ipython/notebook/js/textcell.js
+++ b/public/ipython/notebook/js/textcell.js
@@ -105,7 +105,7 @@ define([
             if (that.keyboard_manager) {
                 that.keyboard_manager.enable();
             }
-          that.code_mirror.setOption('readOnly', !that.kernel.notebook.writable);
+          that.code_mirror.setOption('readOnly', !that.notebook.writable);
         });
         this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this))
         // The tabindex=-1 makes this div focusable.

--- a/public/ipython/notebook/js/textcell.js
+++ b/public/ipython/notebook/js/textcell.js
@@ -105,6 +105,7 @@ define([
             if (that.keyboard_manager) {
                 that.keyboard_manager.enable();
             }
+          that.code_mirror.setOption('readOnly', !that.kernel.notebook.writable);
         });
         this.code_mirror.on('keydown', $.proxy(this.handle_keyevent,this))
         // The tabindex=-1 makes this div focusable.

--- a/public/ipython/tree/js/main.js
+++ b/public/ipython/tree/js/main.js
@@ -46,7 +46,7 @@ require([
     var common_options = {
         base_url: utils.get_body_data("baseUrl"),
         notebook_path: utils.get_body_data("notebookPath"),
-        viewer: utils.get_body_data("viewer"),
+        viewer: utils.get_body_data("viewer_mode"),
     };
     var cfg = new config.ConfigSection('tree', common_options);
     cfg.load();


### PR DESCRIPTION
fixes/improves the https://github.com/andypetrella/spark-notebook/pull/804

- [x] disable cell editing in `VIEWER_MODE`
- [x] do not start kernel/sesssion automatically, but existing charts should stay visible
- [x] cells should also be readonly in readonly view (but not in viewer mode, i.e. `some_nb?read_only=1`)
- [x] Hide: menu, toolbars, `Kernel starting`
- [x] simplify CSS for cell in read_only view (no need for `status bar` below it)
- [x] disable pointer entering cell (so it doesn't appear like editing)
- [x] notebooks list: there should be no `delete/duplicate` buttons
- [x] hide  build info at footer `Build: |  buildTime-Wed Feb 08 13:03:18 EET 2017 | formattedShaVersion-0.8.0-SNAPSHOT-2396b1d423fcdac39696763c2220ba6830e97bd2 | sbtVersion-0.13.8 | scalaVersion-2.11.8 | sparkNotebookVersion-0.8.0-SNAPSHOT | viewer-false | hadoopVersion-2.2.0 | jets3tVersion-0.7.1 | jlineDef-(jline,2.12) | sparkVersion-2.0.0 | withHive-true |.`


Here's what we get now:
<img width="1375" alt="screen shot 2017-02-08 at 13 06 33" src="https://cloud.githubusercontent.com/assets/213426/22734801/a7d0019c-edff-11e6-8bf4-28eef32c28cd.png">



optional (hard to do, maybe not worth it):
- [ ] prevent pressing shift->ENTER: initiating running cells  (it won't run, but looks weird)
- [ ] **show only meaningful menu items which might be nice to see:**
  * Download as: SNB, Scala, MD, PDF
  * `view NB metadata`, `results only view` might be interesting
- [ ] page/window Title shows `(Starting)`



@maasg 
cc @0asa 