### PR TITLE
Fix "edit notebook metadata" formatting

### DIFF
--- a/public/ipython/base/js/dialog.js
+++ b/public/ipython/base/js/dialog.js
@@ -5,6 +5,7 @@ define(function(require) {
     "use strict";
 
     var CodeMirror = require('codemirror/lib/codemirror');
+    var CodeMirrorJsMode = require('codemirror/mode/javascript/javascript');
     var IPython = require('base/js/namespace');
     var $ = require('jquery');
     var ko = require('knockout');

--- a/public/ipython/base/js/dialog.js
+++ b/public/ipython/base/js/dialog.js
@@ -178,6 +178,8 @@ define(function(require) {
             autoIndent: true,
             mode: 'application/json',
         });
+        editor.setSize("100%","400px");
+
         var modal_obj = modal({
             title: "Edit " + options.name + " Metadata",
             body: dialogform,


### PR DESCRIPTION
- Add vertical scroller to edit metadata fixes
- Fix fomatting of "edit metadata" (it was not being collored as JS file for `javascript` mode wasn't loaded)

<img width="695" alt="screen shot 2017-02-08 at 18 59 11" src="https://cloud.githubusercontent.com/assets/213426/22748201/f549fbe4-ee31-11e6-9838-c3ec6fc433e4.png">
