### PR TITLE
add java7-runtime-headless as possible dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ maintainer in Debian := DebianProperties.maintainer
 
 packageDescription := "Interactive and Reactive Data Science using Scala and Spark."
 
-debianPackageDependencies in Debian += "java7-runtime"
+debianPackageDependencies in Debian += "java7-runtime | java7-runtime-headless"
 
 serverLoading in Debian := DebianProperties.serverLoading
 


### PR DESCRIPTION
java8-runtime-headless don't provide anymore "java7-runtime" but only "java7-runtime-headless", we need to add this both possible dependencies