### PR TITLE
Add cell context menu; strip toolbar 

### DIFF
--- a/app/views/notebook.scala.html
+++ b/app/views/notebook.scala.html
@@ -68,8 +68,8 @@
                             title="Open a copy of this notebook's contents and start a new kernel">
                             <a href="#">Make a Copy...</a></li>
                         <li id="rename_notebook"><a href="#">Rename/move...</a></li>
+                        <li id="save_checkpoint"><a href="#">Save the file</a></li>
                         <!--
-                        <li id="save_checkpoint"><a href="#">Save and Checkpoint</a></li>
                         <hr/>
                         <li class="divider"></li>
                         <li id="restore_checkpoint" class="dropdown-submenu"><a href="#">Revert to Checkpoint</a>
@@ -186,30 +186,6 @@
                         <li id="run_all_cells_below" title="Run this cell and all cells below it">
                             <a href="#">Run All Below</a></li>
                         <li class="divider"></li>
-                        <li id="change_cell_type" class="dropdown-submenu"
-                            title="All cells in the notebook have a cell type. By default, new cells are created as 'Code' cells">
-                            <a href="#">Cell Type</a>
-                            <ul class="dropdown-menu">
-                              <li id="to_code"
-                                  title="Contents will be sent to the kernel for execution, and output will display in the footer of cell">
-                                  <a href="#">Code</a></li>
-                              <li id="to_markdown"
-                                  title="Contents will be rendered as HTML and serve as explanatory text">
-                                  <a href="#">Markdown</a></li>
-                              <li id="to_raw"
-                                  title="Contents will pass through nbconvert unmodified">
-                                  <a href="#">Raw NBConvert</a></li>
-                            </ul>
-                        </li>
-                        <li class="divider"></li>
-                        <li id="current_inputs" class="dropdown-submenu"><a href="#">Current Input</a>
-                            <ul class="dropdown-menu">
-                                <li id="toggle_current_input"
-                                    title="Hide/Show the input of the current cell">
-                                    <a href="#">Toggle</a>
-                                </li>
-                            </ul>
-                        </li>
                         <li id="all_inputs" class="dropdown-submenu"><a href="#">All Input</a>
                             <ul class="dropdown-menu">
                                 <li id="toggle_all_input"
@@ -228,22 +204,6 @@
                                 <li id="toggle_all_output_stream"
                                     title="Hide/Show the output stream of all cells">
                                     <a href="#">Toggle All</a>
-                                </li>
-                            </ul>
-                        </li>
-                        <li id="current_outputs" class="dropdown-submenu"><a href="#">Current Output</a>
-                            <ul class="dropdown-menu">
-                                <li id="toggle_current_output"
-                                    title="Hide/Show the output of the current cell">
-                                    <a href="#">Toggle</a>
-                                </li>
-                                <li id="toggle_current_output_scroll"
-                                    title="Scroll the output of the current cell">
-                                    <a href="#">Toggle Scrolling</a>
-                                </li>
-                                <li id="clear_current_output"
-                                    title="Clear the output of the current cell">
-                                    <a href="#">Clear</a>
                                 </li>
                             </ul>
                         </li>

--- a/public/ipython/custom/custom.css
+++ b/public/ipython/custom/custom.css
@@ -178,11 +178,34 @@ div.cell.selected, div.cell.code_cell.selected, .edit_mode div.cell.selected {
 /* make defined variables lighter, so it do not disturb from final result */
 div.output_area pre { color: #666; }
 
+/* code cell context-menu */
+.cell-context-buttons > .btn-group > .btn > .glyphicon { color: #aaa; }
+.cell-context-buttons .btn { padding: 0px 3px; }
+
+div.text_cell .cell-context-buttons { float: right; }
+div.text_cell.unselected .cell-context-buttons {
+  display: none !important; visibility: hidden !important;
+}
+div.text_cell {
+  display: block !important;
+
+  /* unset the flex layout, so buttons would render normaly */
+  -moz-box-orient: unset; -moz-box-align: unset; flex-direction: unset; align-items: unset; box-orient: unset; box-align: unset;
+}
+
+/* hide cell options in read-only view */
+body[data-read-only="true"]  div.cell .cell-context-buttons {
+    display: none !important; visibility: hidden !important;
+}
+
+
 /* codemirror syntax highlighting tweaks */
 .cm-sql-inside-scala-mode {
   background-color: #fffdea;
 }
 
+/* hide the useless main toolbar (with icons/buttons). brute-force for now. */
+#maintoolbar {display: none !important; visibility: hidden !important; }
 
 body[data-read-only="true"] .cell .progress, body[data-read-only="true"] #maintoolbar, body[data-read-only="true"] #menubar-container {
   display: none !important; visibility: hidden!important;

--- a/public/ipython/notebook/js/cell.js
+++ b/public/ipython/notebook/js/cell.js
@@ -126,6 +126,122 @@ define([
     Cell.prototype.create_element = function () {
     };
 
+    Cell.prototype.set_cell_width = function (value) {
+        // we check that the presentation namespace exist and create it if needed
+        if (this.metadata.presentation === undefined) {
+            this.metadata.presentation = {};
+        }
+        // set the value
+        this.metadata.presentation.cell_width = value;
+        this.render();
+    };
+
+    Cell.prototype.get_cell_width = function () {
+        var ns = this.metadata.presentation;
+        // if the presentation namespace does not exist return `undefined`
+        // (will be interpreted as `false` by checkbox) otherwise
+        // return the value
+        return (ns === undefined) ? undefined : ns.cell_width;
+    };
+
+    Cell.prototype.create_context_menu = function() {
+        var theCell = this;
+        console.log("theCell-this:", theCell);
+        var context_menu = $(
+          '\
+          <div class="cell-context-buttons" style="text-align: right">\
+              <div class="btn-group">\
+                <a class="btn" data-menu-command="ipython.run-select-next"><span class="glyphicon glyphicon-play" aria-hidden="true"></span></a>\
+          <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" aria-expanded="false">\
+              <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>\
+          </a>\
+          <a class="btn" data-menu-command="ipython.delete-cell"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>\
+          <ul class="dropdown-menu cell-settings dropdown-menu-right">\
+            <li data-menu-command="ipython.cut-selected-cell"><a tabindex="-1" href="#"><i class="fa-cut fa"></i> Cut Cell</a></li>\
+            <li data-menu-command="ipython.copy-selected-cell"><a tabindex="-1" href="#"><i class="fa-copy fa"></i> Copy cell</a></li>\
+            <li data-menu-command="ipython.paste-cell-after"><a tabindex="-1" href="#"><i class="fa-paste fa"></i> Paste cell below</a></li>\
+            <li class="divider"></li>\
+            <li data-menu-command="ipython.insert-cell-after"><a tabindex="-1" href="#">\
+              <span class="glyphicon glyphicon-plus"></span> Insert cell below</a>\
+            </li>\
+            <li class="divider"></li>\
+            <li data-menu-command="ipython.move-selected-cell-up"><a tabindex="-1" href="#" class="">\
+                <span class="glyphicon glyphicon-chevron-up"></span> Move up</a></li>\
+            <li data-menu-command="ipython.move-selected-cell-down"><a tabindex="-1" href="#" class="">\
+                <span class="glyphicon glyphicon-chevron-down"></span> Move down</a></li>\
+            <li class="divider"></li>\
+            <li class="dropdown-submenu"\
+                title="All cells in the notebook have a cell type. By default, new cells are created as \'Code\' cells">\
+                <a href="#">Cell Type</a>\
+                <ul class="dropdown-menu">\
+                  <li data-menu-command="to_code"\
+                      title="Contents will be sent to the kernel for execution, and output will display in the footer of cell">\
+                      <a href="#">Code</a></li>\
+                  <li data-menu-command="to_markdown"\
+                      title="Contents will be rendered as HTML and serve as explanatory text">\
+                      <a href="#">Markdown</a></li>\
+                  <li data-menu-command="to_heading"\
+                      title="Headings can be linked via URL">\
+                      <a href="#">Heading</a></li>\
+                </ul>\
+            </li>\
+            <li class="dropdown-submenu">\
+                <a tabindex="-1" href="#"><span class="glyphicon glyphicon-resize-horizontal"></span> Set Cell width</a>\
+                <ul class="dropdown-menu">\
+                    <li data-menu-command="set_cell_width" data-cell-width="3"><a tabindex="-1" href="#" class="">25%</a></li>\
+                    <li data-menu-command="set_cell_width" data-cell-width="6"><a tabindex="-1" href="#" class="">50%</a></li>\
+                    <li data-menu-command="set_cell_width" data-cell-width="9"><a tabindex="-1" href="#" class="">75%</a></li>\
+                    <li data-menu-command="set_cell_width" data-cell-width="12"><a tabindex="-1" href="#" class="">100%</a></li>\
+                </ul>\
+            </li>\
+            <li class="divider"></li>\
+            <li data-menu-command="toggle_current_input"><a href="#">Toggle input (code)</a></li>\
+            <li data-menu-command="toggle_current_output"><a href="#">Toggle output</a></li>\
+            <li data-menu-command="clear_current_output"><a tabindex="-1" href="#">\
+              Clear current output</a>\
+            </li>\
+          </ul>\
+          \
+          </div>\
+          </div>\
+'
+        );
+        // bind events (valid only for the currently selected cell)
+        context_menu.find('[data-menu-command]').click(function (event) {
+            event.preventDefault();
+            var command = $(this).data('menu-command');
+            console.log("command:", command);
+            switch(command) {
+                case 'to_code':
+                    IPython.notebook.to_code();
+                    break;
+                case 'to_markdown':
+                    IPython.notebook.to_markdown();
+                    break;
+                case 'to_heading':
+                    IPython.notebook.to_heading();
+                    break;
+                case 'clear_current_output':
+                    IPython.notebook.clear_output();
+                    break;
+                case 'toggle_current_input':
+                    IPython.notebook.toggle_input();
+                    break;
+                case 'toggle_current_output':
+                    IPython.notebook.toggle_output();
+                    break;
+                case 'set_cell_width':
+                    var new_width = $(this).data('cell-width')
+                    theCell.set_cell_width(new_width);
+                    break;
+                default:
+                    IPython.toolbar.actions.call(command);
+            }
+        });
+        return context_menu;
+    };
+
+
     Cell.prototype.update_width_classes = function() {
         // remove old width classes
         for (var i = 1; i <= 12; i++) {

--- a/public/ipython/notebook/js/celltoolbarpresets/presentation.js
+++ b/public/ipython/notebook/js/celltoolbarpresets/presentation.js
@@ -18,22 +18,11 @@ define([
         ],
         // setter
         function (cell, value) {
-            // we check that the presentation namespace exist and create it if needed
-            if (cell.metadata.presentation === undefined) {
-                cell.metadata.presentation = {};
-            }
-            // set the value
-            cell.metadata.presentation.cell_width = value;
-
-            cell.render();
+            cell.set_cell_width(value);
         },
         //geter
         function (cell) {
-            var ns = cell.metadata.presentation;
-            // if the presentation namespace does not exist return `undefined`
-            // (will be interpreted as `false` by checkbox) otherwise
-            // return the value
-            return (ns === undefined) ? undefined : ns.cell_width;
+          return cell.get_cell_width();
         },
         "Cell width");
 

--- a/public/ipython/notebook/js/codecell.js
+++ b/public/ipython/notebook/js/codecell.js
@@ -186,6 +186,8 @@ define([
         cell.attr('tabindex','2');
         cell.attr("data-cell-id", this.cell_id);
 
+        cell.prepend(this.create_context_menu());
+
         var input = $('<div></div>').addClass('input');
         var prompt = $('<div/>').addClass('prompt input_prompt');
         var inner_cell = $('<div/>').addClass('inner_cell');

--- a/public/ipython/notebook/js/maintoolbar.js
+++ b/public/ipython/notebook/js/maintoolbar.js
@@ -37,28 +37,12 @@ define([
             ['ipython.save-notebook'],
             'save-notbook'
           ],
-          [
-            ['ipython.insert-cell-after'],
-            'insert_above_below'],
-          [
-            ['ipython.cut-selected-cell',
-             'ipython.copy-selected-cell',
-             'ipython.paste-cell-after'
-            ] ,
-            'cut_copy_paste'],
-          [
-            ['ipython.move-selected-cell-up',
-             'ipython.move-selected-cell-down'
-            ],
-            'move_up_down'],
-          [ ['ipython.run-select-next',
+          [ [
              'ipython.stop-kernel',
              'ipython.restart-kernel',
              'ipython.interrupt-jobs'
             ],
             'run_int'],
-         ['<add_celltype_list>'],
-         ['<add_celltoolbar_list>']
         ];
         this.construct(grps);
     };

--- a/public/ipython/notebook/js/textcell.js
+++ b/public/ipython/notebook/js/textcell.js
@@ -90,6 +90,8 @@ define([
         var cell = $("<div>").addClass('cell text_cell');
         cell.attr('tabindex','2');
 
+        cell.prepend(this.create_context_menu());
+
         var prompt = $('<div/>').addClass('prompt input_prompt');
         cell.append(prompt);
         var inner_cell = $('<div/>').addClass('inner_cell');

--- a/public/javascripts/notebook/sidebar.js
+++ b/public/javascripts/notebook/sidebar.js
@@ -9,8 +9,8 @@ require(["jquery", "jquery.gridster", "jquerysticky"], function($, gridster, jqu
         parent: "body",
         bottoming: false,
         // used to position the sidebar below the menu
-        // FIXME: we shouldnt hardcode 61px but this returns too-low height if page is scrolled before it's fully loaded
-        offset_top: Math.max($("#menubar-container").outerHeight(), 61)
+        // FIXME: we shouldnt hardcode 33px, but this returns too-low height if page is scrolled before it's fully loaded
+        offset_top: Math.max($("#menubar-container").outerHeight(), 33)
     });
 
     $('a#toggle-sidebar').click(function(){


### PR DESCRIPTION
![context-menu-sample](https://cloud.githubusercontent.com/assets/213426/23175133/2d920cbe-f867-11e6-9fbf-b1fca702ce22.gif)


- [x] add a simple context menu (uses bootstrap)
  * always show for codecells
  * show for the selected text/markdown cell; hide in results/read-only view
- [x] remove these commands related to current cell from top-toolbar and top menu!
- [x] re: the top toolbar which has icons, I propose to simply remove  🚽 it  ! 🌈 
  * now top toolbar has only 4 quite-useless buttons: `save, stop kernel, restart kernel, interrupt runinng cells`
  * The missing commands can be moved to File/Kernel menus.
- [x] update sidebar positioning (after #820 )

cc @ljank @jarutis  @maasg 