### PR TITLE
Improve progressbar for spark 2.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,7 +31,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-stamp" % "5.2.0")
   * better and faster dependency resolution
   * @see https://github.com/alexarchambault/coursier
   */
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC4")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
 /**
   * sbt-updates


### PR DESCRIPTION
sc.statusTracker return quite weird task counts (e.g. neither completedTasks neither numFailedTasks do not include `skipped-tasks`, while totalTasks include them!). 

Do an approximate best guess then based on active-tasks so at least the status bar disappears when tasks are finished ...


fix https://github.com/spark-notebook/spark-notebook/issues/979